### PR TITLE
Remove assembly-script from config

### DIFF
--- a/condor/migration-guide.md
+++ b/condor/migration-guide.md
@@ -60,9 +60,9 @@ Please see instructions below for your specific SDK language:
 - If you are using an SDK not listed in this chapter, please contact the Casper Exchange Support Team.
 
 
-## Important changes/updates in Casper 2.0(Placeholder - Core Team input required)
+## Important changes/updates in Casper 2.0
 
-Casper 2.0 introduces new block structures, transaction formats and retrograde support. More details can be found below/here (LINK or content below).
+Casper 2.0 introduces new block structures, transaction formats and retrograde support. More details can be found below.
 
 ### 1. New Block Structure
    
@@ -108,18 +108,13 @@ At the same time, Casper 1.x deploys will continue to be accepted by Casper 2.0,
 
 - Common scenarios where the sidecar may disconnect and how to mitigate them.
 
-## Minimal vs. Full Migration (Placeholder - Core Team input required)
+## Minimal vs. Full Migration
 
 It is highly recommended to switch entirely to new API endpoints and adopt new transaction formats.
 
 However, where full migration is not feasible in the short term, exchanges may choose to adapt minimal migration. 
 
 Minimal migration will be adapting new block and transaction structures.
-
-
-## Common Integration Issues (Placeholder - Core Team input required)
-
-Placeholder:  Cover anticipated issues, including transaction failures and undelegation nuances.
 
 
 ## Casper Exchange Support Team

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -124,8 +124,7 @@ module.exports = {
                 id: "developers/writing-onchain-code/index",
             },
             items: [
-                "developers/writing-onchain-code/getting-started",
-                "developers/writing-onchain-code/assembly-script",
+                "developers/writing-onchain-code/getting-started",                
                 "developers/writing-onchain-code/simple-contract",
                 "developers/writing-onchain-code/testing-contracts",
                 "developers/writing-onchain-code/upgrading-contracts",


### PR DESCRIPTION
As part of Casper 2.0 Testnet upgrade readiness, promoting docs changes to Production failed.

Per @okorolov; 

> Hi, sorry, but no, the build is broken
> Not the CI build, but the actual code
> https://github.com/casper-network/docs-infra/actions/runs/13911989215/job/38927945412
> So someone should fix the bugs first

The issue was due to; 
assembly script page was removed by [this](https://github.com/casper-network/docs-redux/commit/639617c00a84b06074c7440734c63e11942973b2) commit, but the reference was not [removed](https://github.com/casper-network/docs-redux/blob/dev/config/sidebar.config.js#L128) in `sidebar.config.js`

This PR also addresses minor housekeeping changes in migration-guide.md - i.e. removing references like "Placeholder - Awaiting core team's input".

```bash
        modified:   condor/migration-guide.md
        modified:   config/sidebar.config.js
```