### PR TITLE
Refine the "All PRs" list format for readability to resolve #38

### DIFF
--- a/condor/all-prs.md
+++ b/condor/all-prs.md
@@ -1,432 +1,431 @@
-number|merged_at|url|title|Feature|Change Type
-----|----|----|----|----|----
-3146|2022-07-04 17:59:02+00:00|https://github.com/casper-network/casper-node/pull/3146|GH-3156: Remove inmem global state|ExEng|Refactor
-3169|2022-07-07 11:57:03+00:00|https://github.com/casper-network/casper-node/pull/3169|GH-3157: Move EE's storage module to a crate|ExEng|Refactor
-3183|2022-09-21 14:48:49+00:00|https://github.com/casper-network/casper-node/pull/3183|GH-3182: Add basic data access layer structure|ExEng|Refactor
-3606|2023-01-28 01:47:23+00:00|https://github.com/casper-network/casper-node/pull/3606|Reverting the reversion of Zug-compatible rewards|Zug|Refactor
-3931|2023-05-11 15:40:12+00:00|https://github.com/casper-network/casper-node/pull/3931|Port DES tests and related Zug changes to `feat-2.0`|Zug|Enhance
-3991|2023-05-29 12:42:34+00:00|https://github.com/casper-network/casper-node/pull/3991|New parameters are added in relation to the finality rewards:|Zug|Enhance
-4028|2023-06-13 23:49:02+00:00|https://github.com/casper-network/casper-node/pull/4028|Push chainspec type graph down into casper types|ExEng|Refactor
-4053|2023-06-15 03:03:48+00:00|https://github.com/casper-network/casper-node/pull/4053|Move `Deploy` and its associated types to `casper-types` crate|ExEng|Refactor
-4067|2023-06-27 16:21:02+00:00|https://github.com/casper-network/casper-node/pull/4067|Move block types from casper-node to casper-types|ExEng|Refactor
-4079|2023-06-27 12:08:17+00:00|https://github.com/casper-network/casper-node/pull/4079|Fix serialization issues|Core|Bugfix
-4092|2023-06-28 18:53:17+00:00|https://github.com/casper-network/casper-node/pull/4092|Clean up EE types|ExEng|Refactor
-4101|2023-07-07 17:09:21+00:00|https://github.com/casper-network/casper-node/pull/4101|Add casper-storage to casper-updater|ExEng|Refactor
-4130|2023-08-18 15:11:17+00:00|https://github.com/casper-network/casper-node/pull/4130|Introduce new `Transaction` type|Transaction|Enhance
-4131|2023-07-20 14:55:24+00:00|https://github.com/casper-network/casper-node/pull/4131|Use test_block_builder only for tests|TechDebt|Refactor
-4133|2023-08-11 09:43:05+00:00|https://github.com/casper-network/casper-node/pull/4133|Use execution journal instead of execution effects|Transactions|Refactor
-4162|2023-08-23 21:18:12+00:00|https://github.com/casper-network/casper-node/pull/4162|Transaction enum|Transactions|Enhance
-4163|2023-08-08 16:41:18+00:00|https://github.com/casper-network/casper-node/pull/4163|Introduce AddressableEntity|AddressableEntity|Enhance
-4182|2023-09-01 23:13:16+00:00|https://github.com/casper-network/casper-node/pull/4182|GH-2064: Factory pattern MVP|FactoryPattern|Enhance
-4196|2023-08-28 06:09:35+00:00|https://github.com/casper-network/casper-node/pull/4196|Feat 2.0 bid rework|Rewards|Enhance
-4207|2023-08-14 13:08:25+00:00|https://github.com/casper-network/casper-node/pull/4207|Return early in case of a faulty sender|Zug|Enhance
-4217|2023-09-04 14:34:49+00:00|https://github.com/casper-network/casper-node/pull/4217|Verify that the sync response has been asked for|Zug|Refactor
-4236|2023-09-06 17:23:20+00:00|https://github.com/casper-network/casper-node/pull/4236|Change DeployAcceptor to TransactionAcceptor|Transactions|Enhance
-4241|2023-09-06 20:49:27+00:00|https://github.com/casper-network/casper-node/pull/4241|Transaction gossiper|Transactions|Enhance
-4267|2023-09-12 17:39:26+00:00|https://github.com/casper-network/casper-node/pull/4267|Data extensibility for `Block` and `BlockBody`|DataExtensibility|Enhance
-4286|2023-09-14 12:05:47+00:00|https://github.com/casper-network/casper-node/pull/4286|Fix query_balance to handle addressable_entity|AddressableEntity|Refactor
-4310|2023-10-12 12:33:26+00:00|https://github.com/casper-network/casper-node/pull/4310|Refactor usage of the ContractHash and Key types in preparation for Uref work|ExEng|Refactor
-4320|2023-10-19 12:37:29+00:00|https://github.com/casper-network/casper-node/pull/4320|Disable stored session and rework standard payment|AddressableEntity|Enhance
-4326|2023-10-10 16:20:59+00:00|https://github.com/casper-network/casper-node/pull/4326|Merge SSE event streams|NativeEvents|Enhance
-4351|2023-10-27 13:55:55+00:00|https://github.com/casper-network/casper-node/pull/4351|Transactions on JSON-RPC server|Transactions|Enhance
-4355|2023-10-27 20:30:10+00:00|https://github.com/casper-network/casper-node/pull/4355|Transactions on event stream server|Transactions|Enhance
-4358|2023-10-30 13:31:42+00:00|https://github.com/casper-network/casper-node/pull/4358|Convert `DeployFetcher` to `TransactionFetcher`|Transactions|Enhance
-4370|2023-11-03 21:47:00+00:00|https://github.com/casper-network/casper-node/pull/4370|Contract level messages|NativeEvents|Enhance
-4371|2023-10-24 15:12:53+00:00|https://github.com/casper-network/casper-node/pull/4371|Fix issue in `Key` and increase test coverage|Core|Bugfix
-4376|2023-10-30 17:25:32+00:00|https://github.com/casper-network/casper-node/pull/4376|Fix addressable entity request|AddressableEntity|Bugfix
-4392|2023-11-03 12:52:23+00:00|https://github.com/casper-network/casper-node/pull/4392|Update `BlockV2` to hold `TransactionHash`es|Transactions|Enhance
-4400|2023-11-20 13:15:48+00:00|https://github.com/casper-network/casper-node/pull/4400|Rewards tests setup|Rewards|TestFix
-4421|2024-02-08 20:37:46+00:00|https://github.com/casper-network/casper-node/pull/4421|Rework named keys|AddressableEntity|Enhance
-4440|2023-11-29 16:47:48+00:00|https://github.com/casper-network/casper-node/pull/4440|Rewrite `TransactionV1`|Transactions|TestFix
-4447|2023-12-12 14:45:00+00:00|https://github.com/casper-network/casper-node/pull/4447|Fix several JsonSchema impls and update the schema|Transactions|Refactor
-4458|2023-12-18 17:27:44+00:00|https://github.com/casper-network/casper-node/pull/4458|block_synchronizer: sync transactions|Transactions|Refactor
-4461|2024-02-27 19:18:46+00:00|https://github.com/casper-network/casper-node/pull/4461|Improvements for the contract level messages interface|NativeEvents|Enhance
-4467|2023-12-29 17:37:19+00:00|https://github.com/casper-network/casper-node/pull/4467|Port the BlockValidator changes related to rewards to feat-2.0|Rewards|Enhance
-4491|2024-02-29 20:50:38+00:00|https://github.com/casper-network/casper-node/pull/4491|RPC sidecar changes|Sidecar|Enhance
-4498|2024-02-28 16:48:02+00:00|https://github.com/casper-network/casper-node/pull/4498|Move block store CRUD functionality from the node store component in casper-storage.|Refactor|Enhance
-4517|2024-02-23 12:14:57+00:00|https://github.com/casper-network/casper-node/pull/4517|Implementation for 'Part 2 : Update Gossipers'|Core|Enhance
-4521|2024-02-09 23:33:19+00:00|https://github.com/casper-network/casper-node/pull/4521|TrackingCopy moved to storage crate|ExEng|Refactor
-4523|2024-02-12 18:25:58+00:00|https://github.com/casper-network/casper-node/pull/4523|EraValidators support for data_provider|ExEng|Enhance
-4524|2024-02-12 18:25:58+00:00|https://github.com/casper-network/casper-node/pull/4524|Bids support for data_provider|ExEng|Enhance
-4526|2024-02-12 18:27:20+00:00|https://github.com/casper-network/casper-node/pull/4526|ExecutionResultsChecksum support for data_provider|ExEng|Enhance
-4527|2024-02-12 18:25:58+00:00|https://github.com/casper-network/casper-node/pull/4527|AddressableEntity support for data_provider|ExEng|Enhance
-4528|2024-02-12 18:25:58+00:00|https://github.com/casper-network/casper-node/pull/4528|TotalSupply support for data_provider|ExEng|Enhance
-4529|2024-02-12 18:25:56+00:00|https://github.com/casper-network/casper-node/pull/4529|RoundSeigniorageRate support for data_provider|ExEng|Enhance
-4530|2024-02-12 23:18:03+00:00|https://github.com/casper-network/casper-node/pull/4530|Trie support for data_provider|ExEng|Enhance
-4531|2024-02-12 23:18:01+00:00|https://github.com/casper-network/casper-node/pull/4531|PutTrie support for data_provider|ExEng|Enhance
-4532|2024-02-13 18:55:46+00:00|https://github.com/casper-network/casper-node/pull/4532|Genesis support for data_provider|ExEng|Enhance
-4535|2024-02-14 00:46:09+00:00|https://github.com/casper-network/casper-node/pull/4535|ProtocolUpgrade support for data_provider|ExEng|Enhance
-4538|2024-02-15 23:01:28+00:00|https://github.com/casper-network/casper-node/pull/4538|Fix the build for casper-types with single features enabled.|Core|BuildFix
-4540|2024-02-16 23:01:46+00:00|https://github.com/casper-network/casper-node/pull/4540|initial native transfer wireup|ExEng|Enhance
-4543|2024-02-22 23:26:53+00:00|https://github.com/casper-network/casper-node/pull/4543|Add tests for validation of rewarded finality signatures|Zug|Enhance
-4549|2024-02-22 21:28:05+00:00|https://github.com/casper-network/casper-node/pull/4549|Rewards calculation fixes|Rewards|TestFix
-4550|2024-03-13 03:39:19+00:00|https://github.com/casper-network/casper-node/pull/4550|Implement per block message ids for contract level messages emitted|NativeEvents|Enhance
-4552|2024-03-19 19:33:35+00:00|https://github.com/casper-network/casper-node/pull/4552|Block Vacancy and gas price tracking|ExEng|Enhance
-4565|2024-03-01 20:35:47+00:00|https://github.com/casper-network/casper-node/pull/4565|Native auction support for data_provider|ExEng|Enhance
-4566|2024-05-02 19:45:48+00:00|https://github.com/casper-network/casper-node/pull/4566|Change PublicKey on Bid|Zug|Validator
-4569|2024-06-10 15:26:42+00:00|https://github.com/casper-network/casper-node/pull/4569|Min max delegation amounts|Zug|Delegation
-4570|2024-02-29 11:22:48+00:00|https://github.com/casper-network/casper-node/pull/4570|Update default versions in nctl to 2.0.0|NCTL|Fix
-4583|2024-03-04 13:46:54+00:00|https://github.com/casper-network/casper-node/pull/4583|TaggedValues support of data provider|ExEng|Enhance
-4584|2024-03-06 18:58:59+00:00|https://github.com/casper-network/casper-node/pull/4584|Move ReactorState back to the node and replace with a wrapped String in the binary port|BinaryPort|Refactor
-4585|2024-03-07 18:46:05+00:00|https://github.com/casper-network/casper-node/pull/4585|Add a flag for speculative exec and disable by default|SpecExec|Refactor
-4587|2024-03-11 14:50:48+00:00|https://github.com/casper-network/casper-node/pull/4587|Rename transform types|Core|Refactor
-4589|2024-03-06 21:17:44+00:00|https://github.com/casper-network/casper-node/pull/4589|Remove state from execution engine|ExEng|Refactor
-4590|2024-03-13 01:13:52+00:00|https://github.com/casper-network/casper-node/pull/4590|184 update deploy buffer mods|Transactions|Refactor
-4591|2024-06-10 15:29:23+00:00|https://github.com/casper-network/casper-node/pull/4591|Update Doc disable/enable_contract_version|ExEng|Fix
-4592|2024-03-15 21:03:12+00:00|https://github.com/casper-network/casper-node/pull/4592|Add a binary request for dictionary items|BinaryPort|Sidecar
-4596|2024-03-13 17:18:34+00:00|https://github.com/casper-network/casper-node/pull/4596|Fix `client.sh` nighly test|Core|Fix
-4597|2024-03-11 18:49:34+00:00|https://github.com/casper-network/casper-node/pull/4597|Ensure there is at least one txn when calling `random_with_specifics()`|Transactions|Enhance
-4598|2024-03-13 00:20:54+00:00|https://github.com/casper-network/casper-node/pull/4598|Update example config|Transactions|TestFix
-4599|2024-03-15 22:18:44+00:00|https://github.com/casper-network/casper-node/pull/4599|Expose latest switch block information in the binary port|BinaryPort|Enhance
-4600|2024-03-13 17:18:45+00:00|https://github.com/casper-network/casper-node/pull/4600|Fix block proposer parse in NCTL|NCTL|TestFix
-4601|2024-03-18 16:03:34+00:00|https://github.com/casper-network/casper-node/pull/4601|Minor updates to gossiper comments|Zug|Fix
-4602|2024-03-19 13:06:12+00:00|https://github.com/casper-network/casper-node/pull/4602|ee/contract-messages: use `EntityAddr` for messages|AddressableEntity|Enhance
-4603|2024-03-19 11:55:13+00:00|https://github.com/casper-network/casper-node/pull/4603|nctl/nightly-tests: several script fixes for parsing blocks|Core|FixTest
-4605|2024-03-18 12:56:37+00:00|https://github.com/casper-network/casper-node/pull/4605|Fixes for bond its test|Core|FixTest
-4609|2024-03-19 00:12:25+00:00|https://github.com/casper-network/casper-node/pull/4609|Remove references to deleted files from casper-updater|ExEng|Fix
-4610|2024-03-19 14:24:54+00:00|https://github.com/casper-network/casper-node/pull/4610|Fix upgrade test issues in 2.0|Core|FixTest
-4613|2024-03-19 09:34:18+00:00|https://github.com/casper-network/casper-node/pull/4613|Fixes for network soundness test|Core|FixTest
-4614|2024-03-19 15:34:50+00:00|https://github.com/casper-network/casper-node/pull/4614|Fix emergency upgrade test|Core|FixTest
-4616|2024-03-22 14:13:03+00:00|https://github.com/casper-network/casper-node/pull/4616|Fix upgrade scenario 09 in 2.0|Core|Bugfix
-4617|2024-04-09 16:07:30+00:00|https://github.com/casper-network/casper-node/pull/4617|Fix rewards distribution|Rewards|Bugfix
-4618|2024-03-22 14:13:20+00:00|https://github.com/casper-network/casper-node/pull/4618|Update block parsing code in NCTL|NCTL|Enhance
-4620|2024-03-27 12:02:38+00:00|https://github.com/casper-network/casper-node/pull/4620|Update juliet server settings|Core|Fix
-4622|2024-03-22 14:13:35+00:00|https://github.com/casper-network/casper-node/pull/4622|Use consistent administrator account in both 'accounts' and 'chainspe…|Core|Fix
-4624|2024-03-26 13:57:11+00:00|https://github.com/casper-network/casper-node/pull/4624|Remove redundant flaky test|Tests|FixTest
-4625|2024-03-22 17:08:20+00:00|https://github.com/casper-network/casper-node/pull/4625|Remove `add_session_version`|ExEng|Fix
-4626|2024-03-26 16:26:55+00:00|https://github.com/casper-network/casper-node/pull/4626|Move NCTL to a separate repo|NCTL|Refactor
-4628|2024-04-02 14:33:43+00:00|https://github.com/casper-network/casper-node/pull/4628|Expose dictionary item key in lookup response|BinaryPort|Enhance
-4633|2024-03-28 18:09:58+00:00|https://github.com/casper-network/casper-node/pull/4633|Correct CI json file path|Tests|Fix
-4635|2024-04-04 01:31:35+00:00|https://github.com/casper-network/casper-node/pull/4635|2.0 Integration|ExEng|Massive
-4636|2024-04-02 17:14:50+00:00|https://github.com/casper-network/casper-node/pull/4636|Return None in case of an error in get_addressable_entity|AddressableEntity|Enhance
-4637|2024-03-28 13:38:43+00:00|https://github.com/casper-network/casper-node/pull/4637|Bump juliet|Core|Fix
-4638|2024-03-28 16:54:31+00:00|https://github.com/casper-network/casper-node/pull/4638|Log details of errors related to binary port connectivity|BinaryPort|Refactor
-4640|2024-05-06 22:47:05+00:00|https://github.com/casper-network/casper-node/pull/4640|burn implemented|Core|Enhance
-4642|2024-04-04 13:59:53+00:00|https://github.com/casper-network/casper-node/pull/4642|Decouple Refund and Fee handling|ExEng|Refactor
-4643|2024-04-05 16:42:54+00:00|https://github.com/casper-network/casper-node/pull/4643|Changes needed for downstream apps to work with `feat-2.0`|ExEng|Fix
-4644|2024-04-25 19:57:27+00:00|https://github.com/casper-network/casper-node/pull/4644|Add tracking of size and consumption in determing block utilization|ExEng|Refactor
-4645|2024-04-10 18:11:22+00:00|https://github.com/casper-network/casper-node/pull/4645|Binary port balance query|BinaryPort|Enhance
-4646|2024-04-08 14:30:42+00:00|https://github.com/casper-network/casper-node/pull/4646|Add 'latest_switch_block_hash' field to rest status endpoint|RPC|Enhance
-4648|2024-04-09 13:12:24+00:00|https://github.com/casper-network/casper-node/pull/4648|Fix for StoredValue::ContractPackage not json-deserializable|ExEng|Bugfix
-4649|2024-04-09 18:28:32+00:00|https://github.com/casper-network/casper-node/pull/4649|casper_updater compatibility with Condor and version bumps|Core|Fix
-4650|2024-04-10 15:38:05+00:00|https://github.com/casper-network/casper-node/pull/4650|Fix a bug in the BlockValidator|ExEng|Bugfix
-4652|2024-04-09 03:38:44+00:00|https://github.com/casper-network/casper-node/pull/4652|2.0 ScratchDb fix|ExEng|Enhance
-4653|2024-04-10 16:57:32+00:00|https://github.com/casper-network/casper-node/pull/4653|Use custom Serialize/Deserialize for EntityAddr|AddressableEntity|Enhance
-4657|2024-04-25 12:42:55+00:00|https://github.com/casper-network/casper-node/pull/4657|Prevent stray `accounts.toml` files from breaking upgrades|Core|Bugfix
-4659|2024-04-11 00:21:42+00:00|https://github.com/casper-network/casper-node/pull/4659|Correction of values for expected prod chainspec.toml.|Core|Fix
-4663|2024-04-11 19:58:31+00:00|https://github.com/casper-network/casper-node/pull/4663|Syncing and cleanup of chainspec.toml values|Core|Fix
-4664|2024-04-12 13:57:21+00:00|https://github.com/casper-network/casper-node/pull/4664|Makefile: fix rust smart contracts build|Core|Fix
-4665|2024-04-15 14:12:07+00:00|https://github.com/casper-network/casper-node/pull/4665|Fix issues with custom payment|Core|Bugfix
-4666|2024-04-23 16:08:19+00:00|https://github.com/casper-network/casper-node/pull/4666|Stub implementation of reservations|ExEng|Enhance
-4667|2024-04-15 15:31:55+00:00|https://github.com/casper-network/casper-node/pull/4667|Remove 'json_rpc' crate and handle cors origin for REST server as string|Refactor|Refactor
-4670|2024-04-25 16:23:11+00:00|https://github.com/casper-network/casper-node/pull/4670|Changed the format used to deserialize StoredValue::ContractPackage variant because it broke backwards compatibility.|ExEng|Bugfix
-4671|2024-04-22 17:00:35+00:00|https://github.com/casper-network/casper-node/pull/4671|Amortized gas holds chainspec option|ExEng|Fees
-4674|2024-05-02 18:15:05+00:00|https://github.com/casper-network/casper-node/pull/4674|Update build.rs to eliminate vergen and gitoxide dependencies|Build|Fix
-4677|2024-05-09 14:25:06+00:00|https://github.com/casper-network/casper-node/pull/4677|Re-generate chainspec.toml for EE test support|Build|FixTest
-4678|2024-04-29 19:04:48+00:00|https://github.com/casper-network/casper-node/pull/4678|Remove 'juliet' from the binary port|BinaryPort|Fix
-4679|2024-06-05 16:07:38+00:00|https://github.com/casper-network/casper-node/pull/4679|Fixing ee tests|ExEng|TestFix
-4680|2024-04-29 21:16:07+00:00|https://github.com/casper-network/casper-node/pull/4680|One time migration of accounts and contracts at upgrade|AddressableEntity|Enhance
-4681|2024-04-26 00:08:18+00:00|https://github.com/casper-network/casper-node/pull/4681|Internalize block global and gas hold settings|ExEng|Enhance
-4682|2024-04-27 00:29:00+00:00|https://github.com/casper-network/casper-node/pull/4682|Update emit message costs for production chainspec|NativeEvents|Enhance
-4683|2024-05-10 17:11:56+00:00|https://github.com/casper-network/casper-node/pull/4683|Expand binary port error reporting|BinaryPort|Enhance
-4684|2024-04-30 15:23:38+00:00|https://github.com/casper-network/casper-node/pull/4684|BUGFIX: Custom Payment / No Fee / No Refund interaction|Core|Bugfix
-4687|2024-05-13 15:28:55+00:00|https://github.com/casper-network/casper-node/pull/4687|Block restructure|ExEng|Enhance
-4689|2024-05-07 13:42:56+00:00|https://github.com/casper-network/casper-node/pull/4689|Use a shared enum for key prefixes|BinaryPort|Enhance
-4690|2024-05-03 08:34:01+00:00|https://github.com/casper-network/casper-node/pull/4690|Remove balance by block request|BinaryPort|Enhance
-4691|2024-05-06 00:11:33+00:00|https://github.com/casper-network/casper-node/pull/4691|Migrate entry points|AddressableEntity|Enhance
-4693|2024-05-07 12:12:13+00:00|https://github.com/casper-network/casper-node/pull/4693|Fix version string|Core|Fix
-4699|2024-05-07 15:36:11+00:00|https://github.com/casper-network/casper-node/pull/4699|Use compile-time env rather than runtime for git hash|Core|Fix
-4700|2024-05-08 17:18:38+00:00|https://github.com/casper-network/casper-node/pull/4700|Add ItemsByPrefix request|BinaryPort|Enhance
-4701|2024-05-16 13:53:35+00:00|https://github.com/casper-network/casper-node/pull/4701|NoFee validator credit|ExEng|Fees,Rewards
-4702|2024-05-13 16:05:25+00:00|https://github.com/casper-network/casper-node/pull/4702|BlockSynchronizer: turn down log level|Core|Fix
-4703|2024-05-10 12:02:56+00:00|https://github.com/casper-network/casper-node/pull/4703|Add test counter to nightly tests script|Tests|FixTest
-4704|2024-05-10 19:24:01+00:00|https://github.com/casper-network/casper-node/pull/4704|Fix block vacancy bug|Core|Bugfix
-4705|2024-05-09 19:29:24+00:00|https://github.com/casper-network/casper-node/pull/4705|Fix stalled block synchronizer test|Tests|FixTest
-4711|2024-05-13 22:02:03+00:00|https://github.com/casper-network/casper-node/pull/4711|Efficient byte prefix queries for tracking copy cache|Storage|Optimization
-4712|2024-05-16 18:22:43+00:00|https://github.com/casper-network/casper-node/pull/4712|Fix named key retrieval for system entities in WasmTestBuilder|Tests|FixTest
-4715|2024-05-15 03:31:19+00:00|https://github.com/casper-network/casper-node/pull/4715|Update `DeployBuilder`|Transactions|Fix
-4717|2024-05-17 12:06:45+00:00|https://github.com/casper-network/casper-node/pull/4717|Remove bytesrepr impls from PayloadType|BinaryPort|Refactor
-4718|2024-05-17 18:17:44+00:00|https://github.com/casper-network/casper-node/pull/4718|Fix bid addr key formatting/parsing|Core|Bugfix
-4719|2024-05-21 16:11:36+00:00|https://github.com/casper-network/casper-node/pull/4719|Change the unbonding process to only prune bids after unbonding is processed|Protocol|Enhance
-4720|2024-05-24 16:10:50+00:00|https://github.com/casper-network/casper-node/pull/4720|Transaction buffer improvements|Transactions|Enhance
-4721|2024-05-29 11:45:56+00:00|https://github.com/casper-network/casper-node/pull/4721|Expand standard|Transactions|Enhance
-4722|2024-05-22 14:28:43+00:00|https://github.com/casper-network/casper-node/pull/4722|BUG FIX: native auction uref extension|Core|Bugfix
-4723|2024-05-30 10:25:52+00:00|https://github.com/casper-network/casper-node/pull/4723|Small refactors in support for `casper-db-utils` rewrite.|Core|Refactor
-4725|2024-05-30 13:14:53+00:00|https://github.com/casper-network/casper-node/pull/4725|Fix entry point and argument transaction issues|Transactions|Bugfix
-4726|2024-06-18 15:25:28+00:00|https://github.com/casper-network/casper-node/pull/4726|Introduce Request Id for binary port communication|BinaryPort|Enhance
-4728|2024-05-30 00:51:21+00:00|https://github.com/casper-network/casper-node/pull/4728|Alter reward distribution logic to take account of prior eras' delegator identities and weights|Rewards|Enhance
-4730|2024-05-29 20:02:31+00:00|https://github.com/casper-network/casper-node/pull/4730|Chainspec fixes for lane numberings and slot gas allocations|ExEng|Enhance
-4732|2024-06-05 15:18:36+00:00|https://github.com/casper-network/casper-node/pull/4732|Cherry pick changes for avoiding leaf deserialization|1.X|Fix
-4733|2024-06-04 13:10:24+00:00|https://github.com/casper-network/casper-node/pull/4733|"Remove unused ""gas_hold_handling"" from binary port config"|BinaryPort|Fix
-4734|2024-06-06 12:36:55+00:00|https://github.com/casper-network/casper-node/pull/4734|Protocol upgrade as async task|Protocol|Enhance
-4735|2024-06-06 13:57:24+00:00|https://github.com/casper-network/casper-node/pull/4735|types/transaction/deploy: bring back the `Mint` category for transfers|Transactions|Bugfix
-4736|2024-06-07 17:53:57+00:00|https://github.com/casper-network/casper-node/pull/4736|Initial implementation of a reward request|Rewards|Enhance
-4739|2024-06-06 22:23:17+00:00|https://github.com/casper-network/casper-node/pull/4739|Bump upgrade timeout in config|Upgrade|Fix
-4742|2024-06-17 20:10:18+00:00|https://github.com/casper-network/casper-node/pull/4742|Porting old 1.6 prs|1.X|Fix
-4744|2024-06-17 21:07:57+00:00|https://github.com/casper-network/casper-node/pull/4744|types/transaction: remove `TransactionSessionKind`|Transactions|Refactor
-4745|2024-06-14 19:24:53+00:00|https://github.com/casper-network/casper-node/pull/4745|Caller extension|ExEng|Enhance
-4746|2024-07-09 21:11:24+00:00|https://github.com/casper-network/casper-node/pull/4746|Including new rewards in the changelog|Rewards|Fix
-4747|2024-06-17 15:39:14+00:00|https://github.com/casper-network/casper-node/pull/4747|Remove 'highway.reduced_reward_multiplier' from the chainspec|Protocol|Fix
-4748|2024-06-17 09:12:59+00:00|https://github.com/casper-network/casper-node/pull/4748|Fix flaky 'should_fetch_from_multiple_peers' test|Protocol|FixTest
-4749|2024-06-14 23:52:48+00:00|https://github.com/casper-network/casper-node/pull/4749|Fix incorrect handling of large bids and unbonds|Protocol|Bugfix
-4750|2024-06-21 14:13:25+00:00|https://github.com/casper-network/casper-node/pull/4750|Add a `decode` subcommand to `global-state-update-gen`|Update|Enhance
-4751|2024-06-18 14:00:17+00:00|https://github.com/casper-network/casper-node/pull/4751|contract_runtime: add more metrics|Runtime|Enhance
-4752|2024-06-15 06:00:15+00:00|https://github.com/casper-network/casper-node/pull/4752|quick fix for direct stored exec|Runtime|Bugfix
-4753|2024-06-18 17:28:16+00:00|https://github.com/casper-network/casper-node/pull/4753|Update 'casper-sidecar' CI dependency to point to `feat-2.0` branch|CI|Fix
-4754|2024-06-25 06:05:19+00:00|https://github.com/casper-network/casper-node/pull/4754|Update handling of binary port errors|BinaryPort|Enhance
-4755|2024-06-25 14:52:11+00:00|https://github.com/casper-network/casper-node/pull/4755|Use protocol version from the requested block in reward request|Protocol|Bugfix
-4756|2024-06-21 12:50:38+00:00|https://github.com/casper-network/casper-node/pull/4756|Update RUSTSEC issues|Build|Cleanup
-4757|2024-06-25 13:45:08+00:00|https://github.com/casper-network/casper-node/pull/4757|Add tracing to the binary port component|BinaryPort|Enhance
-4758|2024-06-25 21:38:02+00:00|https://github.com/casper-network/casper-node/pull/4758|Fix an issue where a switch block was executing very slowly (minutes)|ExEng|Enhance
-4759|2024-07-03 20:04:56+00:00|https://github.com/casper-network/casper-node/pull/4759|BUGFIX: include validator credit in snapshot|ExEng|Bugfix
-4760|2024-07-04 14:37:40+00:00|https://github.com/casper-network/casper-node/pull/4760|Keep minimum/maximum delegation amounts when updating bids|Protocol|Bugfix
-4761|2024-06-25 20:23:48+00:00|https://github.com/casper-network/casper-node/pull/4761|Provide more visibility into error codes in binary port|BinaryPort|Enhance
-4762|2024-06-25 22:50:13+00:00|https://github.com/casper-network/casper-node/pull/4762|[BUGFIX]: Fix in account hash indirection for addressable entity|AddressableEntity|Bugfix
-4764|2024-06-26 16:18:48+00:00|https://github.com/casper-network/casper-node/pull/4764|Derive `Serialize` for some of the types|BinaryPort|Enhance
-4765|2024-06-26 13:37:31+00:00|https://github.com/casper-network/casper-node/pull/4765|Minor edits in BINARY_PORT_PROTOCOL.md.|AddressableEntity|Docs
-4767|2024-07-23 14:18:07+00:00|https://github.com/casper-network/casper-node/pull/4767|Lower verbosity of a repeated log|Zug|Enhance
-4770|2024-07-04 13:49:16+00:00|https://github.com/casper-network/casper-node/pull/4770|Expose delegation rate in reward responses|BinaryPort|Enhance
-4775|2024-08-15 16:46:33+00:00|https://github.com/casper-network/casper-node/pull/4775|Precursor for reserved delegator slots|ExEng|Enhance
-4781|2024-07-02 14:51:59+00:00|https://github.com/casper-network/casper-node/pull/4781|Rc3 block validator tests fix|Protocol|TestFix
-4785|2024-07-04 12:54:36+00:00|https://github.com/casper-network/casper-node/pull/4785|"Fix the ""No such contract"" error"|Runtime|Bugfix
-4786|2024-07-18 15:57:53+00:00|https://github.com/casper-network/casper-node/pull/4786|Remove revert on deser in try_get_named_arg introduced in #4569|Runtime|Enhance
-4787|2024-07-05 15:45:24+00:00|https://github.com/casper-network/casper-node/pull/4787|Expose protocol version in NodeStatus|BinaryPort|Enhance
-4789|2024-07-09 20:26:43+00:00|https://github.com/casper-network/casper-node/pull/4789|Fix a bug in rewards calculation and add a test|Runtime|Bugfix
-4795|2024-07-09 18:23:27+00:00|https://github.com/casper-network/casper-node/pull/4795|Drop effects if WASM module execution caused a revert and also add a test for this.|ExEng|Enhance
-4796|2024-07-09 17:33:24+00:00|https://github.com/casper-network/casper-node/pull/4796|Add a version information request|BinaryPort|Enhance
-4798|2024-07-12 13:56:23+00:00|https://github.com/casper-network/casper-node/pull/4798|Migration version bug fix|Upgrade|Bugfix
-4802|2024-07-12 14:56:24+00:00|https://github.com/casper-network/casper-node/pull/4802|Fix unbonding failing if accounts weren't migrated|Upgrade|Bugfix
-4805|2024-07-18 12:09:33+00:00|https://github.com/casper-network/casper-node/pull/4805|Fix issue with multiple balance holds in the same block.|Transactions|Bugfix
-4809|2024-07-23 15:58:07+00:00|https://github.com/casper-network/casper-node/pull/4809|BUGFIX: Fix miswire of min max delegations amount|Runtime|Bugfix
-4810|2024-07-18 13:06:48+00:00|https://github.com/casper-network/casper-node/pull/4810|Bump rust-toolchain to 1.77.2|CI|Cleanup
-4814|2024-07-22 14:55:12+00:00|https://github.com/casper-network/casper-node/pull/4814|Reject transactions with gas price tolerance lower than minimum chain threshold|Transactions|Enhance
-4815|2024-07-25 14:25:09+00:00|https://github.com/casper-network/casper-node/pull/4815|Bump 'vergen' version to dodge RUSTSEC issues|CI|Cleanup
-4816|2024-07-26 13:05:04+00:00|https://github.com/casper-network/casper-node/pull/4816|Return the switch block hash with rewards response|BinaryPort|Enhance
-4817|2024-07-26 16:46:47+00:00|https://github.com/casper-network/casper-node/pull/4817|Add an error code for purse not found for balance requests|BinaryPort|Enhance
-4822|2024-08-13 22:21:19+00:00|https://github.com/casper-network/casper-node/pull/4822|trie store: fix extension node split when inserting key of variable len|Node|Enhance
-4823|2024-09-10 15:51:04+00:00|https://github.com/casper-network/casper-node/pull/4823|Introducing calltable serialization to `TransactionV1` structures subtree.|Transactions|Enhance
-4827|2024-08-14 19:26:14+00:00|https://github.com/casper-network/casper-node/pull/4827|Revert keeping zero bids in the auction state|ExEng|Fix
-4830|2024-08-17 22:49:23+00:00|https://github.com/casper-network/casper-node/pull/4830|Add gas price to appendable block|Node|Enhance
-4831|2024-08-21 00:02:13+00:00|https://github.com/casper-network/casper-node/pull/4831|Consistent carry forward|Upgrade|Enhance
-4836|2024-08-30 20:25:31+00:00|https://github.com/casper-network/casper-node/pull/4836|Add batch write operation to trie store|Node|Enhance
-4840|2024-08-30 12:40:32+00:00|https://github.com/casper-network/casper-node/pull/4840|Bump transaction limits in the `ttl` test for block validator|Transactions|Testfix
-4843|2024-09-05 12:44:34+00:00|https://github.com/casper-network/casper-node/pull/4843|Extend FFI for backwards compatibility|ExEng|Fix
-4844|2024-09-10 13:34:32+00:00|https://github.com/casper-network/casper-node/pull/4844|Port the changes related to handling of unbonds in `global-state-update-gen` to `feat-2.0`|1.X|Enhance
-4845|2024-09-06 16:38:30+00:00|https://github.com/casper-network/casper-node/pull/4845|Implement Entity and Package information requests (redux)|BinaryPort|Enhance
-5169|2025-03-24T22:28:03Z|https://github.com/casper-network/casper-node/pull/5169|Rework deploy lane logic||
-5170|2025-03-24T12:09:56Z|https://github.com/casper-network/casper-node/pull/5170|Updated logging to make it easier to debug issues with utilization sc…||
-5165|2025-03-18T18:13:23Z|https://github.com/casper-network/casper-node/pull/5165|Updating ci.json nctl-related definitions||
-5162|2025-03-14T20:31:17Z|https://github.com/casper-network/casper-node/pull/5162|[Enhancement] No refund of unspent gas if error detected while processing txn||
-5160|2025-03-13T19:11:25Z|https://github.com/casper-network/casper-node/pull/5160|[BUGFIX] Deploy native transfer entry point name resolution||
-5158|2025-03-13T18:11:47Z|https://github.com/casper-network/casper-node/pull/5158|Correcting minimum bid amount to 10_000 CSPR from 100_000 CSPR||
-5157|2025-03-13T12:36:26Z|https://github.com/casper-network/casper-node/pull/5157|[BUGFIX] extend transaction_acceptor coverage||
-5129|2025-03-11T21:17:01Z|https://github.com/casper-network/casper-node/pull/5129|[FEEDBACK-RESPONSE] address various feedback items||
-5153|2025-03-12T17:17:31Z|https://github.com/casper-network/casper-node/pull/5153|[CLEANUP] remove unused scheduling||
-5148|2025-03-12T13:55:19Z|https://github.com/casper-network/casper-node/pull/5148|Fix chainspec inconsistencies||
-5152|2025-03-12T14:10:59Z|https://github.com/casper-network/casper-node/pull/5152|Backfilling missing error variants in binary port error code enum||
-5122|2025-03-11T14:33:48Z|https://github.com/casper-network/casper-node/pull/5122|Port messages API for new Virtual Machine||
-5142|2025-03-10T19:43:27Z|https://github.com/casper-network/casper-node/pull/5142|Use EntityAddr in MessageAddr and EntityVersions||
-5143|2025-03-10T16:56:51Z|https://github.com/casper-network/casper-node/pull/5143|Disable default features in the prometheus crate||
-5123|2025-03-05T20:55:16Z|https://github.com/casper-network/casper-node/pull/5123|Bumping versions needed for crates publish.||
-5125|2025-03-04T15:02:47Z|https://github.com/casper-network/casper-node/pull/5125|[BUGFIX] in payment limited mode payment 0 should be rejected||
-5116|2025-02-28T14:39:39Z|https://github.com/casper-network/casper-node/pull/5116|Fix gas cost calculation in payment limited||
-5108|2025-02-28T12:08:54Z|https://github.com/casper-network/casper-node/pull/5108|Changed the json representation of StoredValue::Contract.entry_points…||
-5113|2025-02-27T14:58:27Z|https://github.com/casper-network/casper-node/pull/5113|Charge for host functions in VM2||
-5120|2025-02-27T05:37:26Z|https://github.com/casper-network/casper-node/pull/5120|[BUGFIX] in payment limited mode payment 0 should be rejected||
-5118|2025-02-26T19:16:24Z|https://github.com/casper-network/casper-node/pull/5118|Tweak logic for purse creation during contract upgrade||
-5111|2025-02-25T16:04:13Z|https://github.com/casper-network/casper-node/pull/5111|Raise unconsumed 0 to baseline||
-5114|2025-02-26T14:33:32Z|https://github.com/casper-network/casper-node/pull/5114|Update to rust 1.85.0||
-5110|2025-02-26T12:49:12Z|https://github.com/casper-network/casper-node/pull/5110|Update toolchain to 1.84.1||
-5107|2025-02-20T11:35:12Z|https://github.com/casper-network/casper-node/pull/5107|Fixed local config file: changed 'blocklist_retain_duration' into 'bl…||
-5106|2025-02-19T20:26:14Z|https://github.com/casper-network/casper-node/pull/5106|Added more logging, changed blocking mechanism to randomize a value i…||
-5105|2025-02-19T17:58:15Z|https://github.com/casper-network/casper-node/pull/5105|capturing invalid proposal scenarios for improved logging||
-5101|2025-02-14T04:21:07Z|https://github.com/casper-network/casper-node/pull/5101|Attempt of fix a Zug stall possibility. This can happen in a situatio…||
-5104|2025-02-14T04:21:05Z|https://github.com/casper-network/casper-node/pull/5104|Zug update scheduling fix||
-5099|2025-02-11T15:54:58Z|https://github.com/casper-network/casper-node/pull/5099|[CLEANUP] several small consistency & docu fixes||
-5098|2025-02-10T17:36:02Z|https://github.com/casper-network/casper-node/pull/5098|[BUGFIX] Custom payment processing||
-5097|2025-02-06T22:00:15Z|https://github.com/casper-network/casper-node/pull/5097|Updating resources/production/config-example.toml.||
-5096|2025-02-06T16:00:59Z|https://github.com/casper-network/casper-node/pull/5096|Fix binary port test||
-5086|2025-02-06T14:40:00Z|https://github.com/casper-network/casper-node/pull/5086|Rename SignedBlockHeader to BlockHeaderWithSignatures||
-5089|2025-02-06T00:36:14Z|https://github.com/casper-network/casper-node/pull/5089|Making a series of fixes to binary port:||
-5094|2025-02-05T22:34:16Z|https://github.com/casper-network/casper-node/pull/5094|[BUGFIX] penalized payment flow correction||
-5095|2025-02-05T21:03:45Z|https://github.com/casper-network/casper-node/pull/5095|Bump dependencies||
-5092|2025-02-05T21:01:48Z|https://github.com/casper-network/casper-node/pull/5092|[BUGFIX] Fix remove_associated_keys||
-5093|2025-02-05T20:31:55Z|https://github.com/casper-network/casper-node/pull/5093|[BUGFIX] Return intended error variants from several auction internal methods||
-5085|2025-02-04T13:01:14Z|https://github.com/casper-network/casper-node/pull/5085|Make the current protocol version availabe via the FFI||
-5084|2025-02-03T16:02:26Z|https://github.com/casper-network/casper-node/pull/5084|Execute two sets of installer code to extend coverage||
-5090|2025-02-03T15:19:06Z|https://github.com/casper-network/casper-node/pull/5090|Bump OpenSSL version||
-5083|2025-01-30T07:12:46Z|https://github.com/casper-network/casper-node/pull/5083|Rename `SignedBlock` struct to `BlockWithSignatures`||
-5076|2025-01-24T13:41:30Z|https://github.com/casper-network/casper-node/pull/5076|GH-5053: Remove unmaintained test contract||
-4694|2025-01-23T12:42:15Z|https://github.com/casper-network/casper-node/pull/4694|chore: remove repetitive words||
-5056|2025-01-23T12:34:25Z|https://github.com/casper-network/casper-node/pull/5056|CI update for GitHub actions in test.||
-5065|2025-01-21T23:28:45Z|https://github.com/casper-network/casper-node/pull/5065|[BUGFIX] Fix small wasm / big args lane assignment||
-5059|2025-01-21T20:18:26Z|https://github.com/casper-network/casper-node/pull/5059|Amend config compliance to check limit of largest wasm lane||
-5066|2025-01-21T19:13:40Z|https://github.com/casper-network/casper-node/pull/5066|[BUGFIX] Retrocompat for SeigniorageAllocation||
-5063|2025-01-21T14:40:41Z|https://github.com/casper-network/casper-node/pull/5063|GH-5058: Handle payment fix||
-5060|2025-01-17T17:19:57Z|https://github.com/casper-network/casper-node/pull/5060|Bump lanes config||
-5055|2025-01-10T15:14:25Z|https://github.com/casper-network/casper-node/pull/5055|Update wasm lane 5.||
-5049|2025-01-09T11:13:22Z|https://github.com/casper-network/casper-node/pull/5049|Fixing binary port decoder to bail out quickly when receiving a big mes…||
-5051|2025-01-03T20:26:23Z|https://github.com/casper-network/casper-node/pull/5051|Make get_package handle `Key::Hash`||
-5038|2024-12-21T01:58:30Z|https://github.com/casper-network/casper-node/pull/5038|feat-2.0 to dev||
-5048|2024-12-21T01:05:23Z|https://github.com/casper-network/casper-node/pull/5048|GH-5039: Tweak costs and chainspec settings||
-5041|2024-12-20T19:31:59Z|https://github.com/casper-network/casper-node/pull/5041|Remove 0_9_0 chainspec||
-5046|2024-12-20T18:25:20Z|https://github.com/casper-network/casper-node/pull/5046|Execution engine changelog||
-5045|2024-12-20T17:27:17Z|https://github.com/casper-network/casper-node/pull/5045|Custom Payment QoL||
-5040|2024-12-18T23:08:54Z|https://github.com/casper-network/casper-node/pull/5040|Added missing error codes for InvalidDeploy errors||
-5037|2024-12-18T00:16:04Z|https://github.com/casper-network/casper-node/pull/5037|Added missing error code for situation when we can't associate a tran…||
-5034|2024-12-17T21:43:57Z|https://github.com/casper-network/casper-node/pull/5034|Renaming StoredValue::LegacyTransfer to StoredValue::Transfer||
-5036|2024-12-17T20:15:02Z|https://github.com/casper-network/casper-node/pull/5036|Adjust transaction byte sizing||
-5021|2024-12-17T15:29:12Z|https://github.com/casper-network/casper-node/pull/5021|Added ""Isolated"" mode for the sync_handling. Running the node in this…||
-5024|2024-12-16T17:07:39Z|https://github.com/casper-network/casper-node/pull/5024|Changed the way transaction lanes are calculated if the transaction h…||
-5022|2024-12-16T16:13:23Z|https://github.com/casper-network/casper-node/pull/5022|Update wasm lanes and opcode costs||
-5020|2024-12-13T17:00:46Z|https://github.com/casper-network/casper-node/pull/5020|Remove `cargo-audit` ignores||
-5023|2024-12-13T15:58:55Z|https://github.com/casper-network/casper-node/pull/5023|Improve transactor acceptor logic.||
-5010|2024-12-11T17:01:35Z|https://github.com/casper-network/casper-node/pull/5010|Make prepayment naming consistent||
-5018|2024-12-11T16:07:10Z|https://github.com/casper-network/casper-node/pull/5018|Make it possible to query BidKind records in smart contracts||
-5016|2024-12-11T11:16:43Z|https://github.com/casper-network/casper-node/pull/5016|Fix invalid cancel_reservations args||
-4988|2024-12-10T15:18:48Z|https://github.com/casper-network/casper-node/pull/4988|GH-4985: Transaction vm2 settings||
-5013|2024-12-10T12:29:29Z|https://github.com/casper-network/casper-node/pull/5013|Fix withdraw bid unbonds||
-5015|2024-12-09T17:03:05Z|https://github.com/casper-network/casper-node/pull/5015|Audit error fix||
-5011|2024-12-05T23:32:37Z|https://github.com/casper-network/casper-node/pull/5011|Don't enforce spending limit when delegating with a purse||
-5014|2024-12-07T01:00:08Z|https://github.com/casper-network/casper-node/pull/5014|Update wasm lanes||
-5005|2024-12-05T09:34:32Z|https://github.com/casper-network/casper-node/pull/5005|Fixed arg_handling code which forced optional arguments to be passed …||
-5002|2024-12-04T22:57:29Z|https://github.com/casper-network/casper-node/pull/5002|[BUGFIX] contract staking context management||
-4990|2024-12-04T16:44:41Z|https://github.com/casper-network/casper-node/pull/4990|Removed TODOs||
-5003|2024-12-04T16:02:50Z|https://github.com/casper-network/casper-node/pull/5003|Use match statements to avoid runtime errors||
-4980|2024-11-27T03:46:38Z|https://github.com/casper-network/casper-node/pull/4980|Some types and enum variants were not properly json-serializing||
-4989|2024-12-03T12:18:57Z|https://github.com/casper-network/casper-node/pull/4989|Removing builder structs from public API of casper-types||
-4987|2024-11-29T11:55:06Z|https://github.com/casper-network/casper-node/pull/4987|Added json-deserialization code to other variants of Key::BidAddr. Al…||
-4982|2024-11-27T18:00:42Z|https://github.com/casper-network/casper-node/pull/4982|Fix visibility for transaction builder methods||
-4981|2024-11-27T17:07:17Z|https://github.com/casper-network/casper-node/pull/4981|Update chainspec gas fees related to bids||
-4960|2024-11-25T19:33:45Z|https://github.com/casper-network/casper-node/pull/4960|Follow up changes for new VM||
-4974|2024-11-25T21:09:07Z|https://github.com/casper-network/casper-node/pull/4974|Introduce cycle-based gas cost model.||
-4976|2024-11-25T17:47:44Z|https://github.com/casper-network/casper-node/pull/4976|[Test] contract staking test contract||
-4965|2024-11-25T18:39:34Z|https://github.com/casper-network/casper-node/pull/4965|Remove uncessary panics in storage||
-4977|2024-11-25T16:44:05Z|https://github.com/casper-network/casper-node/pull/4977|Changed json serialization for Message struct||
-4975|2024-11-23T21:43:53Z|https://github.com/casper-network/casper-node/pull/4975|Changing Transaction::V1 json serialization||
-4971|2024-11-25T12:15:13Z|https://github.com/casper-network/casper-node/pull/4971|Update transaction builder to handle new auction entrypoints||
-4956|2024-11-23T20:39:32Z|https://github.com/casper-network/casper-node/pull/4956|Introducing seigniorage proportion gauge||
-4967|2024-11-23T19:17:10Z|https://github.com/casper-network/casper-node/pull/4967|Contract staking||
-4969|2024-11-21T11:54:11Z|https://github.com/casper-network/casper-node/pull/4969|Fixed bug which caused calling entry points for smart contracts deplo…||
-4958|2024-11-19T19:17:59Z|https://github.com/casper-network/casper-node/pull/4958|Introduced keep alive monitor mechanism in the binary port. Introduce…||
-4961|2024-11-19T21:43:25Z|https://github.com/casper-network/casper-node/pull/4961|[BUGFIX]: Bugfix for add_contract_version post migration with entity enabled||
-4806|2024-11-12T16:56:47Z|https://github.com/casper-network/casper-node/pull/4806|VM2 MVP||
-4953|2024-11-07T17:49:28Z|https://github.com/casper-network/casper-node/pull/4953|Fixing issues with the node upgrading from 1.5.8 to 2.0.0||
-4948|2024-11-08T20:00:36Z|https://github.com/casper-network/casper-node/pull/4948|Host functions for signature verification and Secp256k1 PK Recovery||
-4934|2024-11-06T16:55:05Z|https://github.com/casper-network/casper-node/pull/4934|Misc cleanups||
-4943|2024-11-05T16:52:17Z|https://github.com/casper-network/casper-node/pull/4943|Add catch up & shutdown mode||
-4949|2024-11-05T10:03:00Z|https://github.com/casper-network/casper-node/pull/4949|Adding checks on GetRequest::Record check to make sure that we don't …||
-4944|2024-11-04T16:41:36Z|https://github.com/casper-network/casper-node/pull/4944|Avoid iterating through all rounds when determining validator participation||
-4945|2024-10-31T16:45:21Z|https://github.com/casper-network/casper-node/pull/4945|Fix timeouts growing in Zug when network is stalled||
-4942|2024-10-31T00:04:14Z|https://github.com/casper-network/casper-node/pull/4942|Adjusted binary port default config settings||
-4938|2024-10-30T16:05:44Z|https://github.com/casper-network/casper-node/pull/4938|Add `validate-config` subcommand||
-4937|2024-10-29T10:31:51Z|https://github.com/casper-network/casper-node/pull/4937|Fixed bug which caused install/upgrade transactions to not get added …||
-4932|2024-10-26T00:36:58Z|https://github.com/casper-network/casper-node/pull/4932|Fix handling zero bids in forced_undelegate||
-4933|2024-10-25T23:46:00Z|https://github.com/casper-network/casper-node/pull/4933|Metrics timings||
-4841|2024-10-25T15:47:03Z|https://github.com/casper-network/casper-node/pull/4841|Implement delegator slot reservation||
-4897|2024-10-23T21:52:48Z|https://github.com/casper-network/casper-node/pull/4897|Add chainspec setting to enable Addressable Entity||
-4928|2024-10-22T20:08:38Z|https://github.com/casper-network/casper-node/pull/4928|[BUGFIX]: Fix transfer recording||
-4903|2024-10-22T19:14:56Z|https://github.com/casper-network/casper-node/pull/4903|Implement generic_hash() host function to support hashing algorithms||
-4922|2024-10-22T13:54:03Z|https://github.com/casper-network/casper-node/pull/4922|Remove max_dependencies from chainspec||
-4921|2024-10-21T21:00:05Z|https://github.com/casper-network/casper-node/pull/4921|Nesting wasm config into ""v1"" field so that we can have clear separat…||
-4919|2024-10-21T16:41:25Z|https://github.com/casper-network/casper-node/pull/4919|Replace URLs with CasperLabs/... to casper-network/...||
-4901|2024-10-21T15:46:21Z|https://github.com/casper-network/casper-node/pull/4901|Changed  from enum to struct, moved  variant as a variant which allo…||
-4714|2024-10-21T09:21:35Z|https://github.com/casper-network/casper-node/pull/4714|Complete feature `std-fs-io` in casper-types for wasm compilation||
-4910|2024-10-17T20:17:05Z|https://github.com/casper-network/casper-node/pull/4910|Add minimum bid amount to add and withdraw bid||
-4909|2024-10-17T19:22:58Z|https://github.com/casper-network/casper-node/pull/4909|Backfilled changelog with types that were added, changed, removed||
-4890|2024-10-17T13:47:12Z|https://github.com/casper-network/casper-node/pull/4890|Changing `TransactionV1` structure. From now on a `TransactionV1` con…||
-4900|2024-10-09T20:31:26Z|https://github.com/casper-network/casper-node/pull/4900|Add block info support to EE and Casper VM (#4853)||
-4912|2024-10-11T15:56:15Z|https://github.com/casper-network/casper-node/pull/4912|[BUGFIX] misc payment edge cases||
-4916|2024-10-15T14:19:28Z|https://github.com/casper-network/casper-node/pull/4916|Key::from_formatted_str no longer produces f64 opcodes in wasm||
-4917|2024-10-16T14:35:10Z|https://github.com/casper-network/casper-node/pull/4917|Added QPS rate limiting mechanism to the binary port. The rate limiti…||
-4911|2024-10-14T16:39:35Z|https://github.com/casper-network/casper-node/pull/4911|GH-4164: Update comment||
-4907|2024-10-15T22:14:31Z|https://github.com/casper-network/casper-node/pull/4907|Remove unchecked arithmetic||
-4904|2024-10-10T21:07:00Z|https://github.com/casper-network/casper-node/pull/4904|Enable missing docs warning on EE and storage crates (#4106)||
-4906|2024-10-09T21:23:53Z|https://github.com/casper-network/casper-node/pull/4906|TransferTargetMode fix (#4192)||
-4894|2024-10-03T14:24:33Z|https://github.com/casper-network/casper-node/pull/4894|Bump casper-wasmi, add sign-ext support||
-435|2025-03-24T10:43:40Z|https://github.com/casper-network/casper-sidecar/pull/435|Test rate limiter||
-432|2025-03-21T16:56:00Z|https://github.com/casper-network/casper-sidecar/pull/432|Less cloning||
-430|2025-03-21T13:05:31Z|https://github.com/casper-network/casper-sidecar/pull/430|Fix action limiter by adjusting expiration time||
-433|2025-03-21T11:38:07Z|https://github.com/casper-network/casper-sidecar/pull/433|Revert ""Removing per action limiters""||
-431|2025-03-14T14:32:33Z|https://github.com/casper-network/casper-sidecar/pull/431|Bumping build version to 1.0.3||
-429|2025-03-14T11:54:09Z|https://github.com/casper-network/casper-sidecar/pull/429|Removing per action limiters||
-427|2025-03-12T20:29:24Z|https://github.com/casper-network/casper-sidecar/pull/427|Aligning sidecar with recent changes in the node||
-345|2024-10-25T14:41:07Z|https://github.com/casper-network/casper-sidecar/pull/345|Updating casper-node dependency to use new Transaction definition; up…||
-355|2024-11-14T08:13:35Z|https://github.com/casper-network/casper-sidecar/pull/355|Updating dependency to casper-node; fixing `state_get_auction_info` c…||
-392|2025-01-16T15:24:27Z|https://github.com/casper-network/casper-sidecar/pull/392|Introduced ""state_get_auction_info_v2"" json rpc method.||
-393|2025-01-17T22:44:36Z|https://github.com/casper-network/casper-sidecar/pull/393|Refactoring ""state_get_auction_info"" and ""state_get_auction_info_v2"" …||
-394|2025-01-21T10:18:18Z|https://github.com/casper-network/casper-sidecar/pull/394|Added missing error variants to handle error codes returned by the node.||
-395|2025-01-24T13:51:12Z|https://github.com/casper-network/casper-sidecar/pull/395|Refreshing casper-node dependency, refactoring tests for 'chain_get_e…||
-399|2025-01-29T16:03:41Z|https://github.com/casper-network/casper-sidecar/pull/399|Aligning timeouts to reflect real-world scenarios||
-402|2025-02-06T14:53:26Z|https://github.com/casper-network/casper-sidecar/pull/402|Aligning sidecar with various changes made to nodes binary port||
-417|2025-02-28T14:33:21Z|https://github.com/casper-network/casper-sidecar/pull/417|Updating casper-node dependency, aligning code with those changes||
-419|2025-03-11T17:50:39Z|https://github.com/casper-network/casper-sidecar/pull/419|Added sse example config in `default_debian_config.toml`. Made `limit…||
-418|2025-03-06T08:39:33Z|https://github.com/casper-network/casper-sidecar/pull/418|Update dependnecies; fix testing; apply some clippy suggestions||
-415|2025-02-27T13:30:11Z|https://github.com/casper-network/casper-sidecar/pull/415|Connection limiter||
-416|2025-02-28T14:03:58Z|https://github.com/casper-network/casper-sidecar/pull/416|Quick fix for event_sidecar testing and build||
-385|2025-01-02T13:57:09Z|https://github.com/casper-network/casper-sidecar/pull/385|Repointing casper-node dependency to dev; applying fixes to be aligne…||
-383|2025-02-21T16:17:41Z|https://github.com/casper-network/casper-sidecar/pull/383|Feat 2.0||
-412|2025-02-19T16:29:05Z|https://github.com/casper-network/casper-sidecar/pull/412|CI publish update||
-411|2025-02-18T20:47:33Z|https://github.com/casper-network/casper-sidecar/pull/411|public-read to private for repo ACL||
-410|2025-02-18T20:16:44Z|https://github.com/casper-network/casper-sidecar/pull/410|Removing --no-build from deb.||
-409|2025-02-18T20:11:29Z|https://github.com/casper-network/casper-sidecar/pull/409|Ci publish update||
-407|2025-02-18T17:12:54Z|https://github.com/casper-network/casper-sidecar/pull/407|Correcting aptly version.||
-406|2025-02-18T17:08:49Z|https://github.com/casper-network/casper-sidecar/pull/406|Update variables||
-405|2025-02-18T15:59:06Z|https://github.com/casper-network/casper-sidecar/pull/405|CI Repo Publish Initial Test||
-403|2025-02-11T13:55:18Z|https://github.com/casper-network/casper-sidecar/pull/403|Increase the rate of heartbeat checks across default configs||
-401|2025-01-31T07:33:09Z|https://github.com/casper-network/casper-sidecar/pull/401|Rename SignedBlock to BlockWithSignatures||
-389|2025-01-10T13:16:15Z|https://github.com/casper-network/casper-sidecar/pull/389|Cutting rc3||
-362|2024-11-19T15:20:51Z|https://github.com/casper-network/casper-sidecar/pull/362|updating dependencies to reflect newest ""casper-types""||
-366|2024-11-25T15:57:17Z|https://github.com/casper-network/casper-sidecar/pull/366|Aligning code with recent changes to casper-types, fixing auction_inf…||
-382|2024-12-18T01:31:57Z|https://github.com/casper-network/casper-sidecar/pull/382|aligning with node changes||
-369|2024-11-26T15:15:38Z|https://github.com/casper-network/casper-sidecar/pull/369|Repointing casper-node to v2.0.0-rc5||
-367|2024-11-26T12:20:56Z|https://github.com/casper-network/casper-sidecar/pull/367|Aligning sidecar to latest changes in casper-node||
-374|2024-12-04T12:19:58Z|https://github.com/casper-network/casper-sidecar/pull/374|Aligning code with recent changes in the node||
-378|2024-12-10T22:20:09Z|https://github.com/casper-network/casper-sidecar/pull/378|Bumping dependencies||
-375|2024-12-04T15:52:08Z|https://github.com/casper-network/casper-sidecar/pull/375|Handle standard interrupt signals||
-364|2024-12-03T11:52:10Z|https://github.com/casper-network/casper-sidecar/pull/364|Use local duplicate of `AuctionState` struct||
-357|2024-12-03T10:42:30Z|https://github.com/casper-network/casper-sidecar/pull/357|Validate network name if specified||
-368|2024-11-26T13:20:26Z|https://github.com/casper-network/casper-sidecar/pull/368|Implement keepalive checks||
-358|2024-11-19T15:56:31Z|https://github.com/casper-network/casper-sidecar/pull/358|Make IP & port config consistent across all node connections||
-353|2024-11-13T14:17:35Z|https://github.com/casper-network/casper-sidecar/pull/353|Add config typing for IP/socket addresses||
-349|2024-11-12T11:22:58Z|https://github.com/casper-network/casper-sidecar/pull/349|RPC client graceful reconnect||
-242|2025-03-13T15:55:26Z|https://github.com/casper-ecosystem/casper-client-rs/pull/242|Feat track node 2.0||
-240|2025-03-05T11:18:06Z|https://github.com/casper-ecosystem/casper-client-rs/pull/240|Bumping rust version, putting Cargo.lock into the repo||
-236|2025-02-24T15:09:30Z|https://github.com/casper-ecosystem/casper-client-rs/pull/236|Change default pricing mode||
-234|2025-02-20T17:55:42Z|https://github.com/casper-ecosystem/casper-client-rs/pull/234|Updating publish to new infra.||
-231|2025-02-13T09:04:40Z|https://github.com/casper-ecosystem/casper-client-rs/pull/231|Rename transaction-path arg to wasm-path||
-228|2025-01-24T16:05:07Z|https://github.com/casper-ecosystem/casper-client-rs/pull/228|Add `list-transactions` subcommand||
-224|2025-01-24T16:02:39Z|https://github.com/casper-ecosystem/casper-client-rs/pull/224|Add `put-deploy` deprecation warning||
-226|2025-01-23T15:38:05Z|https://github.com/casper-ecosystem/casper-client-rs/pull/226|Add contract package arg||
-220|2024-12-18T10:07:42Z|https://github.com/casper-ecosystem/casper-client-rs/pull/220|Pub DeployBuilder||
-216|2024-12-10T21:53:35Z|https://github.com/casper-ecosystem/casper-client-rs/pull/216|Applying arg_handling fixes to the client||
-215|2024-12-04T15:11:22Z|https://github.com/casper-ecosystem/casper-client-rs/pull/215|Reflecting clients code to the fact that ""arg_handling"" module is now…||
-218|2024-12-11T09:21:41Z|https://github.com/casper-ecosystem/casper-client-rs/pull/218|Aligning client code with recent node changes||
-219|2024-12-12T08:39:04Z|https://github.com/casper-ecosystem/casper-client-rs/pull/219|Fix cancel reservations args||
-204|2024-11-25T15:52:47Z|https://github.com/casper-ecosystem/casper-client-rs/pull/204|Aligning client with recent changes of casper-types||
-208|2024-11-27T17:28:34Z|https://github.com/casper-ecosystem/casper-client-rs/pull/208|Making transferred-value optional in the CLI. Also, if VM1 is the sel…||
-213|2024-12-03T11:23:16Z|https://github.com/casper-ecosystem/casper-client-rs/pull/213|Typo fixes||
-207|2024-11-29T14:30:10Z|https://github.com/casper-ecosystem/casper-client-rs/pull/207|Add support for new auction entrypoints||
-212|2024-11-29T12:20:57Z|https://github.com/casper-ecosystem/casper-client-rs/pull/212|Remove external transaction & deploy builder dependency||
-205|2024-11-25T20:23:03Z|https://github.com/casper-ecosystem/casper-client-rs/pull/205|Address refactor of Package to SmartContract||
-200|2024-11-19T17:15:44Z|https://github.com/casper-ecosystem/casper-client-rs/pull/200|Remove --gas-limit parameter||
-199|2024-11-19T16:10:01Z|https://github.com/casper-ecosystem/casper-client-rs/pull/199|New execution engine support||
-197|2024-11-07T02:56:43Z|https://github.com/casper-ecosystem/casper-client-rs/pull/197|Update types latest changes||
-196|2024-10-31T12:07:34Z|https://github.com/casper-ecosystem/casper-client-rs/pull/196|arg install-upgrade bug||
-184|2024-10-28T10:04:47Z|https://github.com/casper-ecosystem/casper-client-rs/pull/184|Interaction with Casper smart-contract source code verification service for feat-2.0 branch||
-195|2024-10-24T18:27:10Z|https://github.com/casper-ecosystem/casper-client-rs/pull/195|Fix for remove of `as_entity_addr`||
-153|2024-10-21T09:45:47Z|https://github.com/casper-ecosystem/casper-client-rs/pull/153|Complete feature std-fs-io in casper-client feat-2.0||
-191|2024-10-17T14:21:47Z|https://github.com/casper-ecosystem/casper-client-rs/pull/191|Changing TransactionV1 structure follwing https://github.com/casper-network/casper-node/pull/4890||
-193|2024-10-15T17:53:40Z|https://github.com/casper-ecosystem/casper-client-rs/pull/193|Add json-schema to casper types import||
-295|2025-03-25T16:17:04Z|https://github.com/casper-ecosystem/cep-78-enhanced-nft/pull/295|Update `casper-contract` crate  + Message topic fix||
-294|2025-03-05T20:56:45Z|https://github.com/casper-ecosystem/cep-78-enhanced-nft/pull/294|EntityEntryPoint update||
-291|2025-02-12T12:44:22Z|https://github.com/casper-ecosystem/cep-78-enhanced-nft/pull/291|Update Feat 2.0 branch||
-160|2025-03-11T11:10:05Z|https://github.com/casper-ecosystem/cep18/pull/160|Do not revert on upgrade with same events||
-158|2025-01-28T18:41:18Z|https://github.com/casper-ecosystem/cep18/pull/158|Update Feat 2.0 branch||
-1|2025-02-04T09:02:38Z|https://github.com/casper-ecosystem/casper-binary-port-client/pull/1|Enable wasm32 compilation and runtime of the binary-port-access lib||
-10|2025-03-25T15:11:35Z|https://github.com/casper-ecosystem/casper-binary-port-client/pull/10|Apply changes from https://github.com/casper-network/casper-node/pull/5089||
-11|2025-02-05T17:29:52Z|https://github.com/casper-ecosystem/casper-binary-port-client/pull/11|Make it possible to initialize COUNTER with a custom value||
-9|2025-02-04T15:11:44Z|https://github.com/casper-ecosystem/casper-binary-port-client/pull/9|Rename SignedBlock to BlockWithSignatures||
-7|2025-01-25T20:42:04Z|https://github.com/casper-ecosystem/casper-binary-port-client/pull/7|Implementation of ""raw"" command||
-3|2025-01-17T11:01:36Z|https://github.com/casper-ecosystem/casper-binary-port-client/pull/3|Update DelegatorKind||
-
+| Pull Request                                                                                                                                                                     | Merge Time                | Feature           | Change Type   |
+|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------|:------------------|:--------------|
+| [GH-3156: Remove inmem global state](https://github.com/casper-network/casper-node/pull/3146)                                                                                    | 2022-07-04 17:59:02+00:00 | ExEng             | Refactor      |
+| [GH-3157: Move EE's storage module to a crate](https://github.com/casper-network/casper-node/pull/3169)                                                                          | 2022-07-07 11:57:03+00:00 | ExEng             | Refactor      |
+| [GH-3182: Add basic data access layer structure](https://github.com/casper-network/casper-node/pull/3183)                                                                        | 2022-09-21 14:48:49+00:00 | ExEng             | Refactor      |
+| [Reverting the reversion of Zug-compatible rewards](https://github.com/casper-network/casper-node/pull/3606)                                                                     | 2023-01-28 01:47:23+00:00 | Zug               | Refactor      |
+| [Port DES tests and related Zug changes to `feat-2.0`](https://github.com/casper-network/casper-node/pull/3931)                                                                  | 2023-05-11 15:40:12+00:00 | Zug               | Enhance       |
+| [New parameters are added in relation to the finality rewards:](https://github.com/casper-network/casper-node/pull/3991)                                                         | 2023-05-29 12:42:34+00:00 | Zug               | Enhance       |
+| [Push chainspec type graph down into casper types](https://github.com/casper-network/casper-node/pull/4028)                                                                      | 2023-06-13 23:49:02+00:00 | ExEng             | Refactor      |
+| [Move `Deploy` and its associated types to `casper-types` crate](https://github.com/casper-network/casper-node/pull/4053)                                                        | 2023-06-15 03:03:48+00:00 | ExEng             | Refactor      |
+| [Move block types from casper-node to casper-types](https://github.com/casper-network/casper-node/pull/4067)                                                                     | 2023-06-27 16:21:02+00:00 | ExEng             | Refactor      |
+| [Fix serialization issues](https://github.com/casper-network/casper-node/pull/4079)                                                                                              | 2023-06-27 12:08:17+00:00 | Core              | Bugfix        |
+| [Clean up EE types](https://github.com/casper-network/casper-node/pull/4092)                                                                                                     | 2023-06-28 18:53:17+00:00 | ExEng             | Refactor      |
+| [Add casper-storage to casper-updater](https://github.com/casper-network/casper-node/pull/4101)                                                                                  | 2023-07-07 17:09:21+00:00 | ExEng             | Refactor      |
+| [Introduce new `Transaction` type](https://github.com/casper-network/casper-node/pull/4130)                                                                                      | 2023-08-18 15:11:17+00:00 | Transaction       | Enhance       |
+| [Use test_block_builder only for tests](https://github.com/casper-network/casper-node/pull/4131)                                                                                 | 2023-07-20 14:55:24+00:00 | TechDebt          | Refactor      |
+| [Use execution journal instead of execution effects](https://github.com/casper-network/casper-node/pull/4133)                                                                    | 2023-08-11 09:43:05+00:00 | Transactions      | Refactor      |
+| [Transaction enum](https://github.com/casper-network/casper-node/pull/4162)                                                                                                      | 2023-08-23 21:18:12+00:00 | Transactions      | Enhance       |
+| [Introduce AddressableEntity](https://github.com/casper-network/casper-node/pull/4163)                                                                                           | 2023-08-08 16:41:18+00:00 | AddressableEntity | Enhance       |
+| [GH-2064: Factory pattern MVP](https://github.com/casper-network/casper-node/pull/4182)                                                                                          | 2023-09-01 23:13:16+00:00 | FactoryPattern    | Enhance       |
+| [Feat 2.0 bid rework](https://github.com/casper-network/casper-node/pull/4196)                                                                                                   | 2023-08-28 06:09:35+00:00 | Rewards           | Enhance       |
+| [Return early in case of a faulty sender](https://github.com/casper-network/casper-node/pull/4207)                                                                               | 2023-08-14 13:08:25+00:00 | Zug               | Enhance       |
+| [Verify that the sync response has been asked for](https://github.com/casper-network/casper-node/pull/4217)                                                                      | 2023-09-04 14:34:49+00:00 | Zug               | Refactor      |
+| [Change DeployAcceptor to TransactionAcceptor](https://github.com/casper-network/casper-node/pull/4236)                                                                          | 2023-09-06 17:23:20+00:00 | Transactions      | Enhance       |
+| [Transaction gossiper](https://github.com/casper-network/casper-node/pull/4241)                                                                                                  | 2023-09-06 20:49:27+00:00 | Transactions      | Enhance       |
+| [Data extensibility for `Block` and `BlockBody`](https://github.com/casper-network/casper-node/pull/4267)                                                                        | 2023-09-12 17:39:26+00:00 | DataExtensibility | Enhance       |
+| [Fix query_balance to handle addressable_entity](https://github.com/casper-network/casper-node/pull/4286)                                                                        | 2023-09-14 12:05:47+00:00 | AddressableEntity | Refactor      |
+| [Refactor usage of the ContractHash and Key types in preparation for Uref work](https://github.com/casper-network/casper-node/pull/4310)                                         | 2023-10-12 12:33:26+00:00 | ExEng             | Refactor      |
+| [Disable stored session and rework standard payment](https://github.com/casper-network/casper-node/pull/4320)                                                                    | 2023-10-19 12:37:29+00:00 | AddressableEntity | Enhance       |
+| [Merge SSE event streams](https://github.com/casper-network/casper-node/pull/4326)                                                                                               | 2023-10-10 16:20:59+00:00 | NativeEvents      | Enhance       |
+| [Transactions on JSON-RPC server](https://github.com/casper-network/casper-node/pull/4351)                                                                                       | 2023-10-27 13:55:55+00:00 | Transactions      | Enhance       |
+| [Transactions on event stream server](https://github.com/casper-network/casper-node/pull/4355)                                                                                   | 2023-10-27 20:30:10+00:00 | Transactions      | Enhance       |
+| [Convert `DeployFetcher` to `TransactionFetcher`](https://github.com/casper-network/casper-node/pull/4358)                                                                       | 2023-10-30 13:31:42+00:00 | Transactions      | Enhance       |
+| [Contract level messages](https://github.com/casper-network/casper-node/pull/4370)                                                                                               | 2023-11-03 21:47:00+00:00 | NativeEvents      | Enhance       |
+| [Fix issue in `Key` and increase test coverage](https://github.com/casper-network/casper-node/pull/4371)                                                                         | 2023-10-24 15:12:53+00:00 | Core              | Bugfix        |
+| [Fix addressable entity request](https://github.com/casper-network/casper-node/pull/4376)                                                                                        | 2023-10-30 17:25:32+00:00 | AddressableEntity | Bugfix        |
+| [Update `BlockV2` to hold `TransactionHash`es](https://github.com/casper-network/casper-node/pull/4392)                                                                          | 2023-11-03 12:52:23+00:00 | Transactions      | Enhance       |
+| [Rewards tests setup](https://github.com/casper-network/casper-node/pull/4400)                                                                                                   | 2023-11-20 13:15:48+00:00 | Rewards           | TestFix       |
+| [Rework named keys](https://github.com/casper-network/casper-node/pull/4421)                                                                                                     | 2024-02-08 20:37:46+00:00 | AddressableEntity | Enhance       |
+| [Rewrite `TransactionV1`](https://github.com/casper-network/casper-node/pull/4440)                                                                                               | 2023-11-29 16:47:48+00:00 | Transactions      | TestFix       |
+| [Fix several JsonSchema impls and update the schema](https://github.com/casper-network/casper-node/pull/4447)                                                                    | 2023-12-12 14:45:00+00:00 | Transactions      | Refactor      |
+| [block_synchronizer: sync transactions](https://github.com/casper-network/casper-node/pull/4458)                                                                                 | 2023-12-18 17:27:44+00:00 | Transactions      | Refactor      |
+| [Improvements for the contract level messages interface](https://github.com/casper-network/casper-node/pull/4461)                                                                | 2024-02-27 19:18:46+00:00 | NativeEvents      | Enhance       |
+| [Port the BlockValidator changes related to rewards to feat-2.0](https://github.com/casper-network/casper-node/pull/4467)                                                        | 2023-12-29 17:37:19+00:00 | Rewards           | Enhance       |
+| [RPC sidecar changes](https://github.com/casper-network/casper-node/pull/4491)                                                                                                   | 2024-02-29 20:50:38+00:00 | Sidecar           | Enhance       |
+| [Move block store CRUD functionality from the node store component in casper-storage.](https://github.com/casper-network/casper-node/pull/4498)                                  | 2024-02-28 16:48:02+00:00 | Refactor          | Enhance       |
+| [Implementation for 'Part 2 : Update Gossipers'](https://github.com/casper-network/casper-node/pull/4517)                                                                        | 2024-02-23 12:14:57+00:00 | Core              | Enhance       |
+| [TrackingCopy moved to storage crate](https://github.com/casper-network/casper-node/pull/4521)                                                                                   | 2024-02-09 23:33:19+00:00 | ExEng             | Refactor      |
+| [EraValidators support for data_provider](https://github.com/casper-network/casper-node/pull/4523)                                                                               | 2024-02-12 18:25:58+00:00 | ExEng             | Enhance       |
+| [Bids support for data_provider](https://github.com/casper-network/casper-node/pull/4524)                                                                                        | 2024-02-12 18:25:58+00:00 | ExEng             | Enhance       |
+| [ExecutionResultsChecksum support for data_provider](https://github.com/casper-network/casper-node/pull/4526)                                                                    | 2024-02-12 18:27:20+00:00 | ExEng             | Enhance       |
+| [AddressableEntity support for data_provider](https://github.com/casper-network/casper-node/pull/4527)                                                                           | 2024-02-12 18:25:58+00:00 | ExEng             | Enhance       |
+| [TotalSupply support for data_provider](https://github.com/casper-network/casper-node/pull/4528)                                                                                 | 2024-02-12 18:25:58+00:00 | ExEng             | Enhance       |
+| [RoundSeigniorageRate support for data_provider](https://github.com/casper-network/casper-node/pull/4529)                                                                        | 2024-02-12 18:25:56+00:00 | ExEng             | Enhance       |
+| [Trie support for data_provider](https://github.com/casper-network/casper-node/pull/4530)                                                                                        | 2024-02-12 23:18:03+00:00 | ExEng             | Enhance       |
+| [PutTrie support for data_provider](https://github.com/casper-network/casper-node/pull/4531)                                                                                     | 2024-02-12 23:18:01+00:00 | ExEng             | Enhance       |
+| [Genesis support for data_provider](https://github.com/casper-network/casper-node/pull/4532)                                                                                     | 2024-02-13 18:55:46+00:00 | ExEng             | Enhance       |
+| [ProtocolUpgrade support for data_provider](https://github.com/casper-network/casper-node/pull/4535)                                                                             | 2024-02-14 00:46:09+00:00 | ExEng             | Enhance       |
+| [Fix the build for casper-types with single features enabled.](https://github.com/casper-network/casper-node/pull/4538)                                                          | 2024-02-15 23:01:28+00:00 | Core              | BuildFix      |
+| [initial native transfer wireup](https://github.com/casper-network/casper-node/pull/4540)                                                                                        | 2024-02-16 23:01:46+00:00 | ExEng             | Enhance       |
+| [Add tests for validation of rewarded finality signatures](https://github.com/casper-network/casper-node/pull/4543)                                                              | 2024-02-22 23:26:53+00:00 | Zug               | Enhance       |
+| [Rewards calculation fixes](https://github.com/casper-network/casper-node/pull/4549)                                                                                             | 2024-02-22 21:28:05+00:00 | Rewards           | TestFix       |
+| [Implement per block message ids for contract level messages emitted](https://github.com/casper-network/casper-node/pull/4550)                                                   | 2024-03-13 03:39:19+00:00 | NativeEvents      | Enhance       |
+| [Block Vacancy and gas price tracking](https://github.com/casper-network/casper-node/pull/4552)                                                                                  | 2024-03-19 19:33:35+00:00 | ExEng             | Enhance       |
+| [Native auction support for data_provider](https://github.com/casper-network/casper-node/pull/4565)                                                                              | 2024-03-01 20:35:47+00:00 | ExEng             | Enhance       |
+| [Change PublicKey on Bid](https://github.com/casper-network/casper-node/pull/4566)                                                                                               | 2024-05-02 19:45:48+00:00 | Zug               | Validator     |
+| [Min max delegation amounts](https://github.com/casper-network/casper-node/pull/4569)                                                                                            | 2024-06-10 15:26:42+00:00 | Zug               | Delegation    |
+| [Update default versions in nctl to 2.0.0](https://github.com/casper-network/casper-node/pull/4570)                                                                              | 2024-02-29 11:22:48+00:00 | NCTL              | Fix           |
+| [TaggedValues support of data provider](https://github.com/casper-network/casper-node/pull/4583)                                                                                 | 2024-03-04 13:46:54+00:00 | ExEng             | Enhance       |
+| [Move ReactorState back to the node and replace with a wrapped String in the binary port](https://github.com/casper-network/casper-node/pull/4584)                               | 2024-03-06 18:58:59+00:00 | BinaryPort        | Refactor      |
+| [Add a flag for speculative exec and disable by default](https://github.com/casper-network/casper-node/pull/4585)                                                                | 2024-03-07 18:46:05+00:00 | SpecExec          | Refactor      |
+| [Rename transform types](https://github.com/casper-network/casper-node/pull/4587)                                                                                                | 2024-03-11 14:50:48+00:00 | Core              | Refactor      |
+| [Remove state from execution engine](https://github.com/casper-network/casper-node/pull/4589)                                                                                    | 2024-03-06 21:17:44+00:00 | ExEng             | Refactor      |
+| [184 update deploy buffer mods](https://github.com/casper-network/casper-node/pull/4590)                                                                                         | 2024-03-13 01:13:52+00:00 | Transactions      | Refactor      |
+| [Update Doc disable/enable_contract_version](https://github.com/casper-network/casper-node/pull/4591)                                                                            | 2024-06-10 15:29:23+00:00 | ExEng             | Fix           |
+| [Add a binary request for dictionary items](https://github.com/casper-network/casper-node/pull/4592)                                                                             | 2024-03-15 21:03:12+00:00 | BinaryPort        | Sidecar       |
+| [Fix `client.sh` nighly test](https://github.com/casper-network/casper-node/pull/4596)                                                                                           | 2024-03-13 17:18:34+00:00 | Core              | Fix           |
+| [Ensure there is at least one txn when calling `random_with_specifics()`](https://github.com/casper-network/casper-node/pull/4597)                                               | 2024-03-11 18:49:34+00:00 | Transactions      | Enhance       |
+| [Update example config](https://github.com/casper-network/casper-node/pull/4598)                                                                                                 | 2024-03-13 00:20:54+00:00 | Transactions      | TestFix       |
+| [Expose latest switch block information in the binary port](https://github.com/casper-network/casper-node/pull/4599)                                                             | 2024-03-15 22:18:44+00:00 | BinaryPort        | Enhance       |
+| [Fix block proposer parse in NCTL](https://github.com/casper-network/casper-node/pull/4600)                                                                                      | 2024-03-13 17:18:45+00:00 | NCTL              | TestFix       |
+| [Minor updates to gossiper comments](https://github.com/casper-network/casper-node/pull/4601)                                                                                    | 2024-03-18 16:03:34+00:00 | Zug               | Fix           |
+| [ee/contract-messages: use `EntityAddr` for messages](https://github.com/casper-network/casper-node/pull/4602)                                                                   | 2024-03-19 13:06:12+00:00 | AddressableEntity | Enhance       |
+| [nctl/nightly-tests: several script fixes for parsing blocks](https://github.com/casper-network/casper-node/pull/4603)                                                           | 2024-03-19 11:55:13+00:00 | Core              | FixTest       |
+| [Fixes for bond its test](https://github.com/casper-network/casper-node/pull/4605)                                                                                               | 2024-03-18 12:56:37+00:00 | Core              | FixTest       |
+| [Remove references to deleted files from casper-updater](https://github.com/casper-network/casper-node/pull/4609)                                                                | 2024-03-19 00:12:25+00:00 | ExEng             | Fix           |
+| [Fix upgrade test issues in 2.0](https://github.com/casper-network/casper-node/pull/4610)                                                                                        | 2024-03-19 14:24:54+00:00 | Core              | FixTest       |
+| [Fixes for network soundness test](https://github.com/casper-network/casper-node/pull/4613)                                                                                      | 2024-03-19 09:34:18+00:00 | Core              | FixTest       |
+| [Fix emergency upgrade test](https://github.com/casper-network/casper-node/pull/4614)                                                                                            | 2024-03-19 15:34:50+00:00 | Core              | FixTest       |
+| [Fix upgrade scenario 09 in 2.0](https://github.com/casper-network/casper-node/pull/4616)                                                                                        | 2024-03-22 14:13:03+00:00 | Core              | Bugfix        |
+| [Fix rewards distribution](https://github.com/casper-network/casper-node/pull/4617)                                                                                              | 2024-04-09 16:07:30+00:00 | Rewards           | Bugfix        |
+| [Update block parsing code in NCTL](https://github.com/casper-network/casper-node/pull/4618)                                                                                     | 2024-03-22 14:13:20+00:00 | NCTL              | Enhance       |
+| [Update juliet server settings](https://github.com/casper-network/casper-node/pull/4620)                                                                                         | 2024-03-27 12:02:38+00:00 | Core              | Fix           |
+| [Use consistent administrator account in both 'accounts' and 'chainspe…](https://github.com/casper-network/casper-node/pull/4622)                                                | 2024-03-22 14:13:35+00:00 | Core              | Fix           |
+| [Remove redundant flaky test](https://github.com/casper-network/casper-node/pull/4624)                                                                                           | 2024-03-26 13:57:11+00:00 | Tests             | FixTest       |
+| [Remove `add_session_version`](https://github.com/casper-network/casper-node/pull/4625)                                                                                          | 2024-03-22 17:08:20+00:00 | ExEng             | Fix           |
+| [Move NCTL to a separate repo](https://github.com/casper-network/casper-node/pull/4626)                                                                                          | 2024-03-26 16:26:55+00:00 | NCTL              | Refactor      |
+| [Expose dictionary item key in lookup response](https://github.com/casper-network/casper-node/pull/4628)                                                                         | 2024-04-02 14:33:43+00:00 | BinaryPort        | Enhance       |
+| [Correct CI json file path](https://github.com/casper-network/casper-node/pull/4633)                                                                                             | 2024-03-28 18:09:58+00:00 | Tests             | Fix           |
+| [2.0 Integration](https://github.com/casper-network/casper-node/pull/4635)                                                                                                       | 2024-04-04 01:31:35+00:00 | ExEng             | Massive       |
+| [Return None in case of an error in get_addressable_entity](https://github.com/casper-network/casper-node/pull/4636)                                                             | 2024-04-02 17:14:50+00:00 | AddressableEntity | Enhance       |
+| [Bump juliet](https://github.com/casper-network/casper-node/pull/4637)                                                                                                           | 2024-03-28 13:38:43+00:00 | Core              | Fix           |
+| [Log details of errors related to binary port connectivity](https://github.com/casper-network/casper-node/pull/4638)                                                             | 2024-03-28 16:54:31+00:00 | BinaryPort        | Refactor      |
+| [burn implemented](https://github.com/casper-network/casper-node/pull/4640)                                                                                                      | 2024-05-06 22:47:05+00:00 | Core              | Enhance       |
+| [Decouple Refund and Fee handling](https://github.com/casper-network/casper-node/pull/4642)                                                                                      | 2024-04-04 13:59:53+00:00 | ExEng             | Refactor      |
+| [Changes needed for downstream apps to work with `feat-2.0`](https://github.com/casper-network/casper-node/pull/4643)                                                            | 2024-04-05 16:42:54+00:00 | ExEng             | Fix           |
+| [Add tracking of size and consumption in determing block utilization](https://github.com/casper-network/casper-node/pull/4644)                                                   | 2024-04-25 19:57:27+00:00 | ExEng             | Refactor      |
+| [Binary port balance query](https://github.com/casper-network/casper-node/pull/4645)                                                                                             | 2024-04-10 18:11:22+00:00 | BinaryPort        | Enhance       |
+| [Add 'latest_switch_block_hash' field to rest status endpoint](https://github.com/casper-network/casper-node/pull/4646)                                                          | 2024-04-08 14:30:42+00:00 | RPC               | Enhance       |
+| [Fix for StoredValue::ContractPackage not json-deserializable](https://github.com/casper-network/casper-node/pull/4648)                                                          | 2024-04-09 13:12:24+00:00 | ExEng             | Bugfix        |
+| [casper_updater compatibility with Condor and version bumps](https://github.com/casper-network/casper-node/pull/4649)                                                            | 2024-04-09 18:28:32+00:00 | Core              | Fix           |
+| [Fix a bug in the BlockValidator](https://github.com/casper-network/casper-node/pull/4650)                                                                                       | 2024-04-10 15:38:05+00:00 | ExEng             | Bugfix        |
+| [2.0 ScratchDb fix](https://github.com/casper-network/casper-node/pull/4652)                                                                                                     | 2024-04-09 03:38:44+00:00 | ExEng             | Enhance       |
+| [Use custom Serialize/Deserialize for EntityAddr](https://github.com/casper-network/casper-node/pull/4653)                                                                       | 2024-04-10 16:57:32+00:00 | AddressableEntity | Enhance       |
+| [Prevent stray `accounts.toml` files from breaking upgrades](https://github.com/casper-network/casper-node/pull/4657)                                                            | 2024-04-25 12:42:55+00:00 | Core              | Bugfix        |
+| [Correction of values for expected prod chainspec.toml.](https://github.com/casper-network/casper-node/pull/4659)                                                                | 2024-04-11 00:21:42+00:00 | Core              | Fix           |
+| [Syncing and cleanup of chainspec.toml values](https://github.com/casper-network/casper-node/pull/4663)                                                                          | 2024-04-11 19:58:31+00:00 | Core              | Fix           |
+| [Makefile: fix rust smart contracts build](https://github.com/casper-network/casper-node/pull/4664)                                                                              | 2024-04-12 13:57:21+00:00 | Core              | Fix           |
+| [Fix issues with custom payment](https://github.com/casper-network/casper-node/pull/4665)                                                                                        | 2024-04-15 14:12:07+00:00 | Core              | Bugfix        |
+| [Stub implementation of reservations](https://github.com/casper-network/casper-node/pull/4666)                                                                                   | 2024-04-23 16:08:19+00:00 | ExEng             | Enhance       |
+| [Remove 'json_rpc' crate and handle cors origin for REST server as string](https://github.com/casper-network/casper-node/pull/4667)                                              | 2024-04-15 15:31:55+00:00 | Refactor          | Refactor      |
+| [Changed the format used to deserialize StoredValue::ContractPackage variant because it broke backwards compatibility.](https://github.com/casper-network/casper-node/pull/4670) | 2024-04-25 16:23:11+00:00 | ExEng             | Bugfix        |
+| [Amortized gas holds chainspec option](https://github.com/casper-network/casper-node/pull/4671)                                                                                  | 2024-04-22 17:00:35+00:00 | ExEng             | Fees          |
+| [Update build.rs to eliminate vergen and gitoxide dependencies](https://github.com/casper-network/casper-node/pull/4674)                                                         | 2024-05-02 18:15:05+00:00 | Build             | Fix           |
+| [Re-generate chainspec.toml for EE test support](https://github.com/casper-network/casper-node/pull/4677)                                                                        | 2024-05-09 14:25:06+00:00 | Build             | FixTest       |
+| [Remove 'juliet' from the binary port](https://github.com/casper-network/casper-node/pull/4678)                                                                                  | 2024-04-29 19:04:48+00:00 | BinaryPort        | Fix           |
+| [Fixing ee tests](https://github.com/casper-network/casper-node/pull/4679)                                                                                                       | 2024-06-05 16:07:38+00:00 | ExEng             | TestFix       |
+| [One time migration of accounts and contracts at upgrade](https://github.com/casper-network/casper-node/pull/4680)                                                               | 2024-04-29 21:16:07+00:00 | AddressableEntity | Enhance       |
+| [Internalize block global and gas hold settings](https://github.com/casper-network/casper-node/pull/4681)                                                                        | 2024-04-26 00:08:18+00:00 | ExEng             | Enhance       |
+| [Update emit message costs for production chainspec](https://github.com/casper-network/casper-node/pull/4682)                                                                    | 2024-04-27 00:29:00+00:00 | NativeEvents      | Enhance       |
+| [Expand binary port error reporting](https://github.com/casper-network/casper-node/pull/4683)                                                                                    | 2024-05-10 17:11:56+00:00 | BinaryPort        | Enhance       |
+| [BUGFIX: Custom Payment / No Fee / No Refund interaction](https://github.com/casper-network/casper-node/pull/4684)                                                               | 2024-04-30 15:23:38+00:00 | Core              | Bugfix        |
+| [Block restructure](https://github.com/casper-network/casper-node/pull/4687)                                                                                                     | 2024-05-13 15:28:55+00:00 | ExEng             | Enhance       |
+| [Use a shared enum for key prefixes](https://github.com/casper-network/casper-node/pull/4689)                                                                                    | 2024-05-07 13:42:56+00:00 | BinaryPort        | Enhance       |
+| [Remove balance by block request](https://github.com/casper-network/casper-node/pull/4690)                                                                                       | 2024-05-03 08:34:01+00:00 | BinaryPort        | Enhance       |
+| [Migrate entry points](https://github.com/casper-network/casper-node/pull/4691)                                                                                                  | 2024-05-06 00:11:33+00:00 | AddressableEntity | Enhance       |
+| [Fix version string](https://github.com/casper-network/casper-node/pull/4693)                                                                                                    | 2024-05-07 12:12:13+00:00 | Core              | Fix           |
+| [Use compile-time env rather than runtime for git hash](https://github.com/casper-network/casper-node/pull/4699)                                                                 | 2024-05-07 15:36:11+00:00 | Core              | Fix           |
+| [Add ItemsByPrefix request](https://github.com/casper-network/casper-node/pull/4700)                                                                                             | 2024-05-08 17:18:38+00:00 | BinaryPort        | Enhance       |
+| [NoFee validator credit](https://github.com/casper-network/casper-node/pull/4701)                                                                                                | 2024-05-16 13:53:35+00:00 | ExEng             | Fees,Rewards  |
+| [BlockSynchronizer: turn down log level](https://github.com/casper-network/casper-node/pull/4702)                                                                                | 2024-05-13 16:05:25+00:00 | Core              | Fix           |
+| [Add test counter to nightly tests script](https://github.com/casper-network/casper-node/pull/4703)                                                                              | 2024-05-10 12:02:56+00:00 | Tests             | FixTest       |
+| [Fix block vacancy bug](https://github.com/casper-network/casper-node/pull/4704)                                                                                                 | 2024-05-10 19:24:01+00:00 | Core              | Bugfix        |
+| [Fix stalled block synchronizer test](https://github.com/casper-network/casper-node/pull/4705)                                                                                   | 2024-05-09 19:29:24+00:00 | Tests             | FixTest       |
+| [Efficient byte prefix queries for tracking copy cache](https://github.com/casper-network/casper-node/pull/4711)                                                                 | 2024-05-13 22:02:03+00:00 | Storage           | Optimization  |
+| [Fix named key retrieval for system entities in WasmTestBuilder](https://github.com/casper-network/casper-node/pull/4712)                                                        | 2024-05-16 18:22:43+00:00 | Tests             | FixTest       |
+| [Update `DeployBuilder`](https://github.com/casper-network/casper-node/pull/4715)                                                                                                | 2024-05-15 03:31:19+00:00 | Transactions      | Fix           |
+| [Remove bytesrepr impls from PayloadType](https://github.com/casper-network/casper-node/pull/4717)                                                                               | 2024-05-17 12:06:45+00:00 | BinaryPort        | Refactor      |
+| [Fix bid addr key formatting/parsing](https://github.com/casper-network/casper-node/pull/4718)                                                                                   | 2024-05-17 18:17:44+00:00 | Core              | Bugfix        |
+| [Change the unbonding process to only prune bids after unbonding is processed](https://github.com/casper-network/casper-node/pull/4719)                                          | 2024-05-21 16:11:36+00:00 | Protocol          | Enhance       |
+| [Transaction buffer improvements](https://github.com/casper-network/casper-node/pull/4720)                                                                                       | 2024-05-24 16:10:50+00:00 | Transactions      | Enhance       |
+| [Expand standard](https://github.com/casper-network/casper-node/pull/4721)                                                                                                       | 2024-05-29 11:45:56+00:00 | Transactions      | Enhance       |
+| [BUG FIX: native auction uref extension](https://github.com/casper-network/casper-node/pull/4722)                                                                                | 2024-05-22 14:28:43+00:00 | Core              | Bugfix        |
+| [Small refactors in support for `casper-db-utils` rewrite.](https://github.com/casper-network/casper-node/pull/4723)                                                             | 2024-05-30 10:25:52+00:00 | Core              | Refactor      |
+| [Fix entry point and argument transaction issues](https://github.com/casper-network/casper-node/pull/4725)                                                                       | 2024-05-30 13:14:53+00:00 | Transactions      | Bugfix        |
+| [Introduce Request Id for binary port communication](https://github.com/casper-network/casper-node/pull/4726)                                                                    | 2024-06-18 15:25:28+00:00 | BinaryPort        | Enhance       |
+| [Alter reward distribution logic to take account of prior eras' delegator identities and weights](https://github.com/casper-network/casper-node/pull/4728)                       | 2024-05-30 00:51:21+00:00 | Rewards           | Enhance       |
+| [Chainspec fixes for lane numberings and slot gas allocations](https://github.com/casper-network/casper-node/pull/4730)                                                          | 2024-05-29 20:02:31+00:00 | ExEng             | Enhance       |
+| [Cherry pick changes for avoiding leaf deserialization](https://github.com/casper-network/casper-node/pull/4732)                                                                 | 2024-06-05 15:18:36+00:00 | 1.X               | Fix           |
+| [Remove unused "gas_hold_handling" from binary port config](https://github.com/casper-network/casper-node/pull/4733)                                                             | 2024-06-04 13:10:24+00:00 | BinaryPort        | Fix           |
+| [Protocol upgrade as async task](https://github.com/casper-network/casper-node/pull/4734)                                                                                        | 2024-06-06 12:36:55+00:00 | Protocol          | Enhance       |
+| [types/transaction/deploy: bring back the `Mint` category for transfers](https://github.com/casper-network/casper-node/pull/4735)                                                | 2024-06-06 13:57:24+00:00 | Transactions      | Bugfix        |
+| [Initial implementation of a reward request](https://github.com/casper-network/casper-node/pull/4736)                                                                            | 2024-06-07 17:53:57+00:00 | Rewards           | Enhance       |
+| [Bump upgrade timeout in config](https://github.com/casper-network/casper-node/pull/4739)                                                                                        | 2024-06-06 22:23:17+00:00 | Upgrade           | Fix           |
+| [Porting old 1.6 prs](https://github.com/casper-network/casper-node/pull/4742)                                                                                                   | 2024-06-17 20:10:18+00:00 | 1.X               | Fix           |
+| [types/transaction: remove `TransactionSessionKind`](https://github.com/casper-network/casper-node/pull/4744)                                                                    | 2024-06-17 21:07:57+00:00 | Transactions      | Refactor      |
+| [Caller extension](https://github.com/casper-network/casper-node/pull/4745)                                                                                                      | 2024-06-14 19:24:53+00:00 | ExEng             | Enhance       |
+| [Including new rewards in the changelog](https://github.com/casper-network/casper-node/pull/4746)                                                                                | 2024-07-09 21:11:24+00:00 | Rewards           | Fix           |
+| [Remove 'highway.reduced_reward_multiplier' from the chainspec](https://github.com/casper-network/casper-node/pull/4747)                                                         | 2024-06-17 15:39:14+00:00 | Protocol          | Fix           |
+| [Fix flaky 'should_fetch_from_multiple_peers' test](https://github.com/casper-network/casper-node/pull/4748)                                                                     | 2024-06-17 09:12:59+00:00 | Protocol          | FixTest       |
+| [Fix incorrect handling of large bids and unbonds](https://github.com/casper-network/casper-node/pull/4749)                                                                      | 2024-06-14 23:52:48+00:00 | Protocol          | Bugfix        |
+| [Add a `decode` subcommand to `global-state-update-gen`](https://github.com/casper-network/casper-node/pull/4750)                                                                | 2024-06-21 14:13:25+00:00 | Update            | Enhance       |
+| [contract_runtime: add more metrics](https://github.com/casper-network/casper-node/pull/4751)                                                                                    | 2024-06-18 14:00:17+00:00 | Runtime           | Enhance       |
+| [quick fix for direct stored exec](https://github.com/casper-network/casper-node/pull/4752)                                                                                      | 2024-06-15 06:00:15+00:00 | Runtime           | Bugfix        |
+| [Update 'casper-sidecar' CI dependency to point to `feat-2.0` branch](https://github.com/casper-network/casper-node/pull/4753)                                                   | 2024-06-18 17:28:16+00:00 | CI                | Fix           |
+| [Update handling of binary port errors](https://github.com/casper-network/casper-node/pull/4754)                                                                                 | 2024-06-25 06:05:19+00:00 | BinaryPort        | Enhance       |
+| [Use protocol version from the requested block in reward request](https://github.com/casper-network/casper-node/pull/4755)                                                       | 2024-06-25 14:52:11+00:00 | Protocol          | Bugfix        |
+| [Update RUSTSEC issues](https://github.com/casper-network/casper-node/pull/4756)                                                                                                 | 2024-06-21 12:50:38+00:00 | Build             | Cleanup       |
+| [Add tracing to the binary port component](https://github.com/casper-network/casper-node/pull/4757)                                                                              | 2024-06-25 13:45:08+00:00 | BinaryPort        | Enhance       |
+| [Fix an issue where a switch block was executing very slowly (minutes)](https://github.com/casper-network/casper-node/pull/4758)                                                 | 2024-06-25 21:38:02+00:00 | ExEng             | Enhance       |
+| [BUGFIX: include validator credit in snapshot](https://github.com/casper-network/casper-node/pull/4759)                                                                          | 2024-07-03 20:04:56+00:00 | ExEng             | Bugfix        |
+| [Keep minimum/maximum delegation amounts when updating bids](https://github.com/casper-network/casper-node/pull/4760)                                                            | 2024-07-04 14:37:40+00:00 | Protocol          | Bugfix        |
+| [Provide more visibility into error codes in binary port](https://github.com/casper-network/casper-node/pull/4761)                                                               | 2024-06-25 20:23:48+00:00 | BinaryPort        | Enhance       |
+| [[BUGFIX]: Fix in account hash indirection for addressable entity](https://github.com/casper-network/casper-node/pull/4762)                                                      | 2024-06-25 22:50:13+00:00 | AddressableEntity | Bugfix        |
+| [Derive `Serialize` for some of the types](https://github.com/casper-network/casper-node/pull/4764)                                                                              | 2024-06-26 16:18:48+00:00 | BinaryPort        | Enhance       |
+| [Minor edits in BINARY_PORT_PROTOCOL.md.](https://github.com/casper-network/casper-node/pull/4765)                                                                               | 2024-06-26 13:37:31+00:00 | AddressableEntity | Docs          |
+| [Lower verbosity of a repeated log](https://github.com/casper-network/casper-node/pull/4767)                                                                                     | 2024-07-23 14:18:07+00:00 | Zug               | Enhance       |
+| [Expose delegation rate in reward responses](https://github.com/casper-network/casper-node/pull/4770)                                                                            | 2024-07-04 13:49:16+00:00 | BinaryPort        | Enhance       |
+| [Precursor for reserved delegator slots](https://github.com/casper-network/casper-node/pull/4775)                                                                                | 2024-08-15 16:46:33+00:00 | ExEng             | Enhance       |
+| [Rc3 block validator tests fix](https://github.com/casper-network/casper-node/pull/4781)                                                                                         | 2024-07-02 14:51:59+00:00 | Protocol          | TestFix       |
+| [Fix the "No such contract" error](https://github.com/casper-network/casper-node/pull/4785)                                                                                      | 2024-07-04 12:54:36+00:00 | Runtime           | Bugfix        |
+| [Remove revert on deser in try_get_named_arg introduced in #4569](https://github.com/casper-network/casper-node/pull/4786)                                                       | 2024-07-18 15:57:53+00:00 | Runtime           | Enhance       |
+| [Expose protocol version in NodeStatus](https://github.com/casper-network/casper-node/pull/4787)                                                                                 | 2024-07-05 15:45:24+00:00 | BinaryPort        | Enhance       |
+| [Fix a bug in rewards calculation and add a test](https://github.com/casper-network/casper-node/pull/4789)                                                                       | 2024-07-09 20:26:43+00:00 | Runtime           | Bugfix        |
+| [Drop effects if WASM module execution caused a revert and also add a test for this.](https://github.com/casper-network/casper-node/pull/4795)                                   | 2024-07-09 18:23:27+00:00 | ExEng             | Enhance       |
+| [Add a version information request](https://github.com/casper-network/casper-node/pull/4796)                                                                                     | 2024-07-09 17:33:24+00:00 | BinaryPort        | Enhance       |
+| [Migration version bug fix](https://github.com/casper-network/casper-node/pull/4798)                                                                                             | 2024-07-12 13:56:23+00:00 | Upgrade           | Bugfix        |
+| [Fix unbonding failing if accounts weren't migrated](https://github.com/casper-network/casper-node/pull/4802)                                                                    | 2024-07-12 14:56:24+00:00 | Upgrade           | Bugfix        |
+| [Fix issue with multiple balance holds in the same block.](https://github.com/casper-network/casper-node/pull/4805)                                                              | 2024-07-18 12:09:33+00:00 | Transactions      | Bugfix        |
+| [BUGFIX: Fix miswire of min max delegations amount](https://github.com/casper-network/casper-node/pull/4809)                                                                     | 2024-07-23 15:58:07+00:00 | Runtime           | Bugfix        |
+| [Bump rust-toolchain to 1.77.2](https://github.com/casper-network/casper-node/pull/4810)                                                                                         | 2024-07-18 13:06:48+00:00 | CI                | Cleanup       |
+| [Reject transactions with gas price tolerance lower than minimum chain threshold](https://github.com/casper-network/casper-node/pull/4814)                                       | 2024-07-22 14:55:12+00:00 | Transactions      | Enhance       |
+| [Bump 'vergen' version to dodge RUSTSEC issues](https://github.com/casper-network/casper-node/pull/4815)                                                                         | 2024-07-25 14:25:09+00:00 | CI                | Cleanup       |
+| [Return the switch block hash with rewards response](https://github.com/casper-network/casper-node/pull/4816)                                                                    | 2024-07-26 13:05:04+00:00 | BinaryPort        | Enhance       |
+| [Add an error code for purse not found for balance requests](https://github.com/casper-network/casper-node/pull/4817)                                                            | 2024-07-26 16:46:47+00:00 | BinaryPort        | Enhance       |
+| [trie store: fix extension node split when inserting key of variable len](https://github.com/casper-network/casper-node/pull/4822)                                               | 2024-08-13 22:21:19+00:00 | Node              | Enhance       |
+| [Introducing calltable serialization to `TransactionV1` structures subtree.](https://github.com/casper-network/casper-node/pull/4823)                                            | 2024-09-10 15:51:04+00:00 | Transactions      | Enhance       |
+| [Revert keeping zero bids in the auction state](https://github.com/casper-network/casper-node/pull/4827)                                                                         | 2024-08-14 19:26:14+00:00 | ExEng             | Fix           |
+| [Add gas price to appendable block](https://github.com/casper-network/casper-node/pull/4830)                                                                                     | 2024-08-17 22:49:23+00:00 | Node              | Enhance       |
+| [Consistent carry forward](https://github.com/casper-network/casper-node/pull/4831)                                                                                              | 2024-08-21 00:02:13+00:00 | Upgrade           | Enhance       |
+| [Add batch write operation to trie store](https://github.com/casper-network/casper-node/pull/4836)                                                                               | 2024-08-30 20:25:31+00:00 | Node              | Enhance       |
+| [Bump transaction limits in the `ttl` test for block validator](https://github.com/casper-network/casper-node/pull/4840)                                                         | 2024-08-30 12:40:32+00:00 | Transactions      | Testfix       |
+| [Extend FFI for backwards compatibility](https://github.com/casper-network/casper-node/pull/4843)                                                                                | 2024-09-05 12:44:34+00:00 | ExEng             | Fix           |
+| [Port the changes related to handling of unbonds in `global-state-update-gen` to `feat-2.0`](https://github.com/casper-network/casper-node/pull/4844)                            | 2024-09-10 13:34:32+00:00 | 1.X               | Enhance       |
+| [Implement Entity and Package information requests (redux)](https://github.com/casper-network/casper-node/pull/4845)                                                             | 2024-09-06 16:38:30+00:00 | BinaryPort        | Enhance       |
+| [Rework deploy lane logic](https://github.com/casper-network/casper-node/pull/5169)                                                                                              | 2025-03-24T22:28:03Z      |                   |               |
+| [Updated logging to make it easier to debug issues with utilization sc…](https://github.com/casper-network/casper-node/pull/5170)                                                | 2025-03-24T12:09:56Z      |                   |               |
+| [Updating ci.json nctl-related definitions](https://github.com/casper-network/casper-node/pull/5165)                                                                             | 2025-03-18T18:13:23Z      |                   |               |
+| [[Enhancement] No refund of unspent gas if error detected while processing txn](https://github.com/casper-network/casper-node/pull/5162)                                         | 2025-03-14T20:31:17Z      |                   |               |
+| [[BUGFIX] Deploy native transfer entry point name resolution](https://github.com/casper-network/casper-node/pull/5160)                                                           | 2025-03-13T19:11:25Z      |                   |               |
+| [Correcting minimum bid amount to 10_000 CSPR from 100_000 CSPR](https://github.com/casper-network/casper-node/pull/5158)                                                        | 2025-03-13T18:11:47Z      |                   |               |
+| [[BUGFIX] extend transaction_acceptor coverage](https://github.com/casper-network/casper-node/pull/5157)                                                                         | 2025-03-13T12:36:26Z      |                   |               |
+| [[FEEDBACK-RESPONSE] address various feedback items](https://github.com/casper-network/casper-node/pull/5129)                                                                    | 2025-03-11T21:17:01Z      |                   |               |
+| [[CLEANUP] remove unused scheduling](https://github.com/casper-network/casper-node/pull/5153)                                                                                    | 2025-03-12T17:17:31Z      |                   |               |
+| [Fix chainspec inconsistencies](https://github.com/casper-network/casper-node/pull/5148)                                                                                         | 2025-03-12T13:55:19Z      |                   |               |
+| [Backfilling missing error variants in binary port error code enum](https://github.com/casper-network/casper-node/pull/5152)                                                     | 2025-03-12T14:10:59Z      |                   |               |
+| [Port messages API for new Virtual Machine](https://github.com/casper-network/casper-node/pull/5122)                                                                             | 2025-03-11T14:33:48Z      |                   |               |
+| [Use EntityAddr in MessageAddr and EntityVersions](https://github.com/casper-network/casper-node/pull/5142)                                                                      | 2025-03-10T19:43:27Z      |                   |               |
+| [Disable default features in the prometheus crate](https://github.com/casper-network/casper-node/pull/5143)                                                                      | 2025-03-10T16:56:51Z      |                   |               |
+| [Bumping versions needed for crates publish.](https://github.com/casper-network/casper-node/pull/5123)                                                                           | 2025-03-05T20:55:16Z      |                   |               |
+| [[BUGFIX] in payment limited mode payment 0 should be rejected](https://github.com/casper-network/casper-node/pull/5125)                                                         | 2025-03-04T15:02:47Z      |                   |               |
+| [Fix gas cost calculation in payment limited](https://github.com/casper-network/casper-node/pull/5116)                                                                           | 2025-02-28T14:39:39Z      |                   |               |
+| [Changed the json representation of StoredValue::Contract.entry_points…](https://github.com/casper-network/casper-node/pull/5108)                                                | 2025-02-28T12:08:54Z      |                   |               |
+| [Charge for host functions in VM2](https://github.com/casper-network/casper-node/pull/5113)                                                                                      | 2025-02-27T14:58:27Z      |                   |               |
+| [[BUGFIX] in payment limited mode payment 0 should be rejected](https://github.com/casper-network/casper-node/pull/5120)                                                         | 2025-02-27T05:37:26Z      |                   |               |
+| [Tweak logic for purse creation during contract upgrade](https://github.com/casper-network/casper-node/pull/5118)                                                                | 2025-02-26T19:16:24Z      |                   |               |
+| [Raise unconsumed 0 to baseline](https://github.com/casper-network/casper-node/pull/5111)                                                                                        | 2025-02-25T16:04:13Z      |                   |               |
+| [Update to rust 1.85.0](https://github.com/casper-network/casper-node/pull/5114)                                                                                                 | 2025-02-26T14:33:32Z      |                   |               |
+| [Update toolchain to 1.84.1](https://github.com/casper-network/casper-node/pull/5110)                                                                                            | 2025-02-26T12:49:12Z      |                   |               |
+| [Fixed local config file: changed 'blocklist_retain_duration' into 'bl…](https://github.com/casper-network/casper-node/pull/5107)                                                | 2025-02-20T11:35:12Z      |                   |               |
+| [Added more logging, changed blocking mechanism to randomize a value i…](https://github.com/casper-network/casper-node/pull/5106)                                                | 2025-02-19T20:26:14Z      |                   |               |
+| [capturing invalid proposal scenarios for improved logging](https://github.com/casper-network/casper-node/pull/5105)                                                             | 2025-02-19T17:58:15Z      |                   |               |
+| [Attempt of fix a Zug stall possibility. This can happen in a situatio…](https://github.com/casper-network/casper-node/pull/5101)                                                | 2025-02-14T04:21:07Z      |                   |               |
+| [Zug update scheduling fix](https://github.com/casper-network/casper-node/pull/5104)                                                                                             | 2025-02-14T04:21:05Z      |                   |               |
+| [[CLEANUP] several small consistency & docu fixes](https://github.com/casper-network/casper-node/pull/5099)                                                                      | 2025-02-11T15:54:58Z      |                   |               |
+| [[BUGFIX] Custom payment processing](https://github.com/casper-network/casper-node/pull/5098)                                                                                    | 2025-02-10T17:36:02Z      |                   |               |
+| [Updating resources/production/config-example.toml.](https://github.com/casper-network/casper-node/pull/5097)                                                                    | 2025-02-06T22:00:15Z      |                   |               |
+| [Fix binary port test](https://github.com/casper-network/casper-node/pull/5096)                                                                                                  | 2025-02-06T16:00:59Z      |                   |               |
+| [Rename SignedBlockHeader to BlockHeaderWithSignatures](https://github.com/casper-network/casper-node/pull/5086)                                                                 | 2025-02-06T14:40:00Z      |                   |               |
+| [Making a series of fixes to binary port:](https://github.com/casper-network/casper-node/pull/5089)                                                                              | 2025-02-06T00:36:14Z      |                   |               |
+| [[BUGFIX] penalized payment flow correction](https://github.com/casper-network/casper-node/pull/5094)                                                                            | 2025-02-05T22:34:16Z      |                   |               |
+| [Bump dependencies](https://github.com/casper-network/casper-node/pull/5095)                                                                                                     | 2025-02-05T21:03:45Z      |                   |               |
+| [[BUGFIX] Fix remove_associated_keys](https://github.com/casper-network/casper-node/pull/5092)                                                                                   | 2025-02-05T21:01:48Z      |                   |               |
+| [[BUGFIX] Return intended error variants from several auction internal methods](https://github.com/casper-network/casper-node/pull/5093)                                         | 2025-02-05T20:31:55Z      |                   |               |
+| [Make the current protocol version availabe via the FFI](https://github.com/casper-network/casper-node/pull/5085)                                                                | 2025-02-04T13:01:14Z      |                   |               |
+| [Execute two sets of installer code to extend coverage](https://github.com/casper-network/casper-node/pull/5084)                                                                 | 2025-02-03T16:02:26Z      |                   |               |
+| [Bump OpenSSL version](https://github.com/casper-network/casper-node/pull/5090)                                                                                                  | 2025-02-03T15:19:06Z      |                   |               |
+| [Rename `SignedBlock` struct to `BlockWithSignatures`](https://github.com/casper-network/casper-node/pull/5083)                                                                  | 2025-01-30T07:12:46Z      |                   |               |
+| [GH-5053: Remove unmaintained test contract](https://github.com/casper-network/casper-node/pull/5076)                                                                            | 2025-01-24T13:41:30Z      |                   |               |
+| [chore: remove repetitive words](https://github.com/casper-network/casper-node/pull/4694)                                                                                        | 2025-01-23T12:42:15Z      |                   |               |
+| [CI update for GitHub actions in test.](https://github.com/casper-network/casper-node/pull/5056)                                                                                 | 2025-01-23T12:34:25Z      |                   |               |
+| [[BUGFIX] Fix small wasm / big args lane assignment](https://github.com/casper-network/casper-node/pull/5065)                                                                    | 2025-01-21T23:28:45Z      |                   |               |
+| [Amend config compliance to check limit of largest wasm lane](https://github.com/casper-network/casper-node/pull/5059)                                                           | 2025-01-21T20:18:26Z      |                   |               |
+| [[BUGFIX] Retrocompat for SeigniorageAllocation](https://github.com/casper-network/casper-node/pull/5066)                                                                        | 2025-01-21T19:13:40Z      |                   |               |
+| [GH-5058: Handle payment fix](https://github.com/casper-network/casper-node/pull/5063)                                                                                           | 2025-01-21T14:40:41Z      |                   |               |
+| [Bump lanes config](https://github.com/casper-network/casper-node/pull/5060)                                                                                                     | 2025-01-17T17:19:57Z      |                   |               |
+| [Update wasm lane 5.](https://github.com/casper-network/casper-node/pull/5055)                                                                                                   | 2025-01-10T15:14:25Z      |                   |               |
+| [Fixing binary port decoder to bail out quickly when receiving a big mes…](https://github.com/casper-network/casper-node/pull/5049)                                              | 2025-01-09T11:13:22Z      |                   |               |
+| [Make get_package handle `Key::Hash`](https://github.com/casper-network/casper-node/pull/5051)                                                                                   | 2025-01-03T20:26:23Z      |                   |               |
+| [feat-2.0 to dev](https://github.com/casper-network/casper-node/pull/5038)                                                                                                       | 2024-12-21T01:58:30Z      |                   |               |
+| [GH-5039: Tweak costs and chainspec settings](https://github.com/casper-network/casper-node/pull/5048)                                                                           | 2024-12-21T01:05:23Z      |                   |               |
+| [Remove 0_9_0 chainspec](https://github.com/casper-network/casper-node/pull/5041)                                                                                                | 2024-12-20T19:31:59Z      |                   |               |
+| [Execution engine changelog](https://github.com/casper-network/casper-node/pull/5046)                                                                                            | 2024-12-20T18:25:20Z      |                   |               |
+| [Custom Payment QoL](https://github.com/casper-network/casper-node/pull/5045)                                                                                                    | 2024-12-20T17:27:17Z      |                   |               |
+| [Added missing error codes for InvalidDeploy errors](https://github.com/casper-network/casper-node/pull/5040)                                                                    | 2024-12-18T23:08:54Z      |                   |               |
+| [Added missing error code for situation when we can't associate a tran…](https://github.com/casper-network/casper-node/pull/5037)                                                | 2024-12-18T00:16:04Z      |                   |               |
+| [Renaming StoredValue::LegacyTransfer to StoredValue::Transfer](https://github.com/casper-network/casper-node/pull/5034)                                                         | 2024-12-17T21:43:57Z      |                   |               |
+| [Adjust transaction byte sizing](https://github.com/casper-network/casper-node/pull/5036)                                                                                        | 2024-12-17T20:15:02Z      |                   |               |
+| [Added ""Isolated"" mode for the sync_handling. Running the node in this…](https://github.com/casper-network/casper-node/pull/5021)                                              | 2024-12-17T15:29:12Z      |                   |               |
+| [Changed the way transaction lanes are calculated if the transaction h…](https://github.com/casper-network/casper-node/pull/5024)                                                | 2024-12-16T17:07:39Z      |                   |               |
+| [Update wasm lanes and opcode costs](https://github.com/casper-network/casper-node/pull/5022)                                                                                    | 2024-12-16T16:13:23Z      |                   |               |
+| [Remove `cargo-audit` ignores](https://github.com/casper-network/casper-node/pull/5020)                                                                                          | 2024-12-13T17:00:46Z      |                   |               |
+| [Improve transactor acceptor logic.](https://github.com/casper-network/casper-node/pull/5023)                                                                                    | 2024-12-13T15:58:55Z      |                   |               |
+| [Make prepayment naming consistent](https://github.com/casper-network/casper-node/pull/5010)                                                                                     | 2024-12-11T17:01:35Z      |                   |               |
+| [Make it possible to query BidKind records in smart contracts](https://github.com/casper-network/casper-node/pull/5018)                                                          | 2024-12-11T16:07:10Z      |                   |               |
+| [Fix invalid cancel_reservations args](https://github.com/casper-network/casper-node/pull/5016)                                                                                  | 2024-12-11T11:16:43Z      |                   |               |
+| [GH-4985: Transaction vm2 settings](https://github.com/casper-network/casper-node/pull/4988)                                                                                     | 2024-12-10T15:18:48Z      |                   |               |
+| [Fix withdraw bid unbonds](https://github.com/casper-network/casper-node/pull/5013)                                                                                              | 2024-12-10T12:29:29Z      |                   |               |
+| [Audit error fix](https://github.com/casper-network/casper-node/pull/5015)                                                                                                       | 2024-12-09T17:03:05Z      |                   |               |
+| [Don't enforce spending limit when delegating with a purse](https://github.com/casper-network/casper-node/pull/5011)                                                             | 2024-12-05T23:32:37Z      |                   |               |
+| [Update wasm lanes](https://github.com/casper-network/casper-node/pull/5014)                                                                                                     | 2024-12-07T01:00:08Z      |                   |               |
+| [Fixed arg_handling code which forced optional arguments to be passed …](https://github.com/casper-network/casper-node/pull/5005)                                                | 2024-12-05T09:34:32Z      |                   |               |
+| [[BUGFIX] contract staking context management](https://github.com/casper-network/casper-node/pull/5002)                                                                          | 2024-12-04T22:57:29Z      |                   |               |
+| [Removed TODOs](https://github.com/casper-network/casper-node/pull/4990)                                                                                                         | 2024-12-04T16:44:41Z      |                   |               |
+| [Use match statements to avoid runtime errors](https://github.com/casper-network/casper-node/pull/5003)                                                                          | 2024-12-04T16:02:50Z      |                   |               |
+| [Some types and enum variants were not properly json-serializing](https://github.com/casper-network/casper-node/pull/4980)                                                       | 2024-11-27T03:46:38Z      |                   |               |
+| [Removing builder structs from public API of casper-types](https://github.com/casper-network/casper-node/pull/4989)                                                              | 2024-12-03T12:18:57Z      |                   |               |
+| [Added json-deserialization code to other variants of Key::BidAddr. Al…](https://github.com/casper-network/casper-node/pull/4987)                                                | 2024-11-29T11:55:06Z      |                   |               |
+| [Fix visibility for transaction builder methods](https://github.com/casper-network/casper-node/pull/4982)                                                                        | 2024-11-27T18:00:42Z      |                   |               |
+| [Update chainspec gas fees related to bids](https://github.com/casper-network/casper-node/pull/4981)                                                                             | 2024-11-27T17:07:17Z      |                   |               |
+| [Follow up changes for new VM](https://github.com/casper-network/casper-node/pull/4960)                                                                                          | 2024-11-25T19:33:45Z      |                   |               |
+| [Introduce cycle-based gas cost model.](https://github.com/casper-network/casper-node/pull/4974)                                                                                 | 2024-11-25T21:09:07Z      |                   |               |
+| [[Test] contract staking test contract](https://github.com/casper-network/casper-node/pull/4976)                                                                                 | 2024-11-25T17:47:44Z      |                   |               |
+| [Remove uncessary panics in storage](https://github.com/casper-network/casper-node/pull/4965)                                                                                    | 2024-11-25T18:39:34Z      |                   |               |
+| [Changed json serialization for Message struct](https://github.com/casper-network/casper-node/pull/4977)                                                                         | 2024-11-25T16:44:05Z      |                   |               |
+| [Changing Transaction::V1 json serialization](https://github.com/casper-network/casper-node/pull/4975)                                                                           | 2024-11-23T21:43:53Z      |                   |               |
+| [Update transaction builder to handle new auction entrypoints](https://github.com/casper-network/casper-node/pull/4971)                                                          | 2024-11-25T12:15:13Z      |                   |               |
+| [Introducing seigniorage proportion gauge](https://github.com/casper-network/casper-node/pull/4956)                                                                              | 2024-11-23T20:39:32Z      |                   |               |
+| [Contract staking](https://github.com/casper-network/casper-node/pull/4967)                                                                                                      | 2024-11-23T19:17:10Z      |                   |               |
+| [Fixed bug which caused calling entry points for smart contracts deplo…](https://github.com/casper-network/casper-node/pull/4969)                                                | 2024-11-21T11:54:11Z      |                   |               |
+| [Introduced keep alive monitor mechanism in the binary port. Introduce…](https://github.com/casper-network/casper-node/pull/4958)                                                | 2024-11-19T19:17:59Z      |                   |               |
+| [[BUGFIX]: Bugfix for add_contract_version post migration with entity enabled](https://github.com/casper-network/casper-node/pull/4961)                                          | 2024-11-19T21:43:25Z      |                   |               |
+| [VM2 MVP](https://github.com/casper-network/casper-node/pull/4806)                                                                                                               | 2024-11-12T16:56:47Z      |                   |               |
+| [Fixing issues with the node upgrading from 1.5.8 to 2.0.0](https://github.com/casper-network/casper-node/pull/4953)                                                             | 2024-11-07T17:49:28Z      |                   |               |
+| [Host functions for signature verification and Secp256k1 PK Recovery](https://github.com/casper-network/casper-node/pull/4948)                                                   | 2024-11-08T20:00:36Z      |                   |               |
+| [Misc cleanups](https://github.com/casper-network/casper-node/pull/4934)                                                                                                         | 2024-11-06T16:55:05Z      |                   |               |
+| [Add catch up & shutdown mode](https://github.com/casper-network/casper-node/pull/4943)                                                                                          | 2024-11-05T16:52:17Z      |                   |               |
+| [Adding checks on GetRequest::Record check to make sure that we don't …](https://github.com/casper-network/casper-node/pull/4949)                                                | 2024-11-05T10:03:00Z      |                   |               |
+| [Avoid iterating through all rounds when determining validator participation](https://github.com/casper-network/casper-node/pull/4944)                                           | 2024-11-04T16:41:36Z      |                   |               |
+| [Fix timeouts growing in Zug when network is stalled](https://github.com/casper-network/casper-node/pull/4945)                                                                   | 2024-10-31T16:45:21Z      |                   |               |
+| [Adjusted binary port default config settings](https://github.com/casper-network/casper-node/pull/4942)                                                                          | 2024-10-31T00:04:14Z      |                   |               |
+| [Add `validate-config` subcommand](https://github.com/casper-network/casper-node/pull/4938)                                                                                      | 2024-10-30T16:05:44Z      |                   |               |
+| [Fixed bug which caused install/upgrade transactions to not get added …](https://github.com/casper-network/casper-node/pull/4937)                                                | 2024-10-29T10:31:51Z      |                   |               |
+| [Fix handling zero bids in forced_undelegate](https://github.com/casper-network/casper-node/pull/4932)                                                                           | 2024-10-26T00:36:58Z      |                   |               |
+| [Metrics timings](https://github.com/casper-network/casper-node/pull/4933)                                                                                                       | 2024-10-25T23:46:00Z      |                   |               |
+| [Implement delegator slot reservation](https://github.com/casper-network/casper-node/pull/4841)                                                                                  | 2024-10-25T15:47:03Z      |                   |               |
+| [Add chainspec setting to enable Addressable Entity](https://github.com/casper-network/casper-node/pull/4897)                                                                    | 2024-10-23T21:52:48Z      |                   |               |
+| [[BUGFIX]: Fix transfer recording](https://github.com/casper-network/casper-node/pull/4928)                                                                                      | 2024-10-22T20:08:38Z      |                   |               |
+| [Implement generic_hash() host function to support hashing algorithms](https://github.com/casper-network/casper-node/pull/4903)                                                  | 2024-10-22T19:14:56Z      |                   |               |
+| [Remove max_dependencies from chainspec](https://github.com/casper-network/casper-node/pull/4922)                                                                                | 2024-10-22T13:54:03Z      |                   |               |
+| [Nesting wasm config into ""v1"" field so that we can have clear separat…](https://github.com/casper-network/casper-node/pull/4921)                                              | 2024-10-21T21:00:05Z      |                   |               |
+| [Replace URLs with CasperLabs/... to casper-network/...](https://github.com/casper-network/casper-node/pull/4919)                                                                | 2024-10-21T16:41:25Z      |                   |               |
+| [Changed  from enum to struct, moved  variant as a variant which allo…](https://github.com/casper-network/casper-node/pull/4901)                                                 | 2024-10-21T15:46:21Z      |                   |               |
+| [Complete feature `std-fs-io` in casper-types for wasm compilation](https://github.com/casper-network/casper-node/pull/4714)                                                     | 2024-10-21T09:21:35Z      |                   |               |
+| [Add minimum bid amount to add and withdraw bid](https://github.com/casper-network/casper-node/pull/4910)                                                                        | 2024-10-17T20:17:05Z      |                   |               |
+| [Backfilled changelog with types that were added, changed, removed](https://github.com/casper-network/casper-node/pull/4909)                                                     | 2024-10-17T19:22:58Z      |                   |               |
+| [Changing `TransactionV1` structure. From now on a `TransactionV1` con…](https://github.com/casper-network/casper-node/pull/4890)                                                | 2024-10-17T13:47:12Z      |                   |               |
+| [Add block info support to EE and Casper VM (#4853)](https://github.com/casper-network/casper-node/pull/4900)                                                                    | 2024-10-09T20:31:26Z      |                   |               |
+| [[BUGFIX] misc payment edge cases](https://github.com/casper-network/casper-node/pull/4912)                                                                                      | 2024-10-11T15:56:15Z      |                   |               |
+| [Key::from_formatted_str no longer produces f64 opcodes in wasm](https://github.com/casper-network/casper-node/pull/4916)                                                        | 2024-10-15T14:19:28Z      |                   |               |
+| [Added QPS rate limiting mechanism to the binary port. The rate limiti…](https://github.com/casper-network/casper-node/pull/4917)                                                | 2024-10-16T14:35:10Z      |                   |               |
+| [GH-4164: Update comment](https://github.com/casper-network/casper-node/pull/4911)                                                                                               | 2024-10-14T16:39:35Z      |                   |               |
+| [Remove unchecked arithmetic](https://github.com/casper-network/casper-node/pull/4907)                                                                                           | 2024-10-15T22:14:31Z      |                   |               |
+| [Enable missing docs warning on EE and storage crates (#4106)](https://github.com/casper-network/casper-node/pull/4904)                                                          | 2024-10-10T21:07:00Z      |                   |               |
+| [TransferTargetMode fix (#4192)](https://github.com/casper-network/casper-node/pull/4906)                                                                                        | 2024-10-09T21:23:53Z      |                   |               |
+| [Bump casper-wasmi, add sign-ext support](https://github.com/casper-network/casper-node/pull/4894)                                                                               | 2024-10-03T14:24:33Z      |                   |               |
+| [Test rate limiter](https://github.com/casper-network/casper-sidecar/pull/435)                                                                                                   | 2025-03-24T10:43:40Z      |                   |               |
+| [Less cloning](https://github.com/casper-network/casper-sidecar/pull/432)                                                                                                        | 2025-03-21T16:56:00Z      |                   |               |
+| [Fix action limiter by adjusting expiration time](https://github.com/casper-network/casper-sidecar/pull/430)                                                                     | 2025-03-21T13:05:31Z      |                   |               |
+| [Revert ""Removing per action limiters""](https://github.com/casper-network/casper-sidecar/pull/433)                                                                             | 2025-03-21T11:38:07Z      |                   |               |
+| [Bumping build version to 1.0.3](https://github.com/casper-network/casper-sidecar/pull/431)                                                                                      | 2025-03-14T14:32:33Z      |                   |               |
+| [Removing per action limiters](https://github.com/casper-network/casper-sidecar/pull/429)                                                                                        | 2025-03-14T11:54:09Z      |                   |               |
+| [Aligning sidecar with recent changes in the node](https://github.com/casper-network/casper-sidecar/pull/427)                                                                    | 2025-03-12T20:29:24Z      |                   |               |
+| [Updating casper-node dependency to use new Transaction definition; up…](https://github.com/casper-network/casper-sidecar/pull/345)                                              | 2024-10-25T14:41:07Z      |                   |               |
+| [Updating dependency to casper-node; fixing `state_get_auction_info` c…](https://github.com/casper-network/casper-sidecar/pull/355)                                              | 2024-11-14T08:13:35Z      |                   |               |
+| [Introduced ""state_get_auction_info_v2"" json rpc method.](https://github.com/casper-network/casper-sidecar/pull/392)                                                           | 2025-01-16T15:24:27Z      |                   |               |
+| [Refactoring ""state_get_auction_info"" and ""state_get_auction_info_v2"" …](https://github.com/casper-network/casper-sidecar/pull/393)                                          | 2025-01-17T22:44:36Z      |                   |               |
+| [Added missing error variants to handle error codes returned by the node.](https://github.com/casper-network/casper-sidecar/pull/394)                                            | 2025-01-21T10:18:18Z      |                   |               |
+| [Refreshing casper-node dependency, refactoring tests for 'chain_get_e…](https://github.com/casper-network/casper-sidecar/pull/395)                                              | 2025-01-24T13:51:12Z      |                   |               |
+| [Aligning timeouts to reflect real-world scenarios](https://github.com/casper-network/casper-sidecar/pull/399)                                                                   | 2025-01-29T16:03:41Z      |                   |               |
+| [Aligning sidecar with various changes made to nodes binary port](https://github.com/casper-network/casper-sidecar/pull/402)                                                     | 2025-02-06T14:53:26Z      |                   |               |
+| [Updating casper-node dependency, aligning code with those changes](https://github.com/casper-network/casper-sidecar/pull/417)                                                   | 2025-02-28T14:33:21Z      |                   |               |
+| [Added sse example config in `default_debian_config.toml`. Made `limit…](https://github.com/casper-network/casper-sidecar/pull/419)                                              | 2025-03-11T17:50:39Z      |                   |               |
+| [Update dependnecies; fix testing; apply some clippy suggestions](https://github.com/casper-network/casper-sidecar/pull/418)                                                     | 2025-03-06T08:39:33Z      |                   |               |
+| [Connection limiter](https://github.com/casper-network/casper-sidecar/pull/415)                                                                                                  | 2025-02-27T13:30:11Z      |                   |               |
+| [Quick fix for event_sidecar testing and build](https://github.com/casper-network/casper-sidecar/pull/416)                                                                       | 2025-02-28T14:03:58Z      |                   |               |
+| [Repointing casper-node dependency to dev; applying fixes to be aligne…](https://github.com/casper-network/casper-sidecar/pull/385)                                              | 2025-01-02T13:57:09Z      |                   |               |
+| [Feat 2.0](https://github.com/casper-network/casper-sidecar/pull/383)                                                                                                            | 2025-02-21T16:17:41Z      |                   |               |
+| [CI publish update](https://github.com/casper-network/casper-sidecar/pull/412)                                                                                                   | 2025-02-19T16:29:05Z      |                   |               |
+| [public-read to private for repo ACL](https://github.com/casper-network/casper-sidecar/pull/411)                                                                                 | 2025-02-18T20:47:33Z      |                   |               |
+| [Removing --no-build from deb.](https://github.com/casper-network/casper-sidecar/pull/410)                                                                                       | 2025-02-18T20:16:44Z      |                   |               |
+| [Ci publish update](https://github.com/casper-network/casper-sidecar/pull/409)                                                                                                   | 2025-02-18T20:11:29Z      |                   |               |
+| [Correcting aptly version.](https://github.com/casper-network/casper-sidecar/pull/407)                                                                                           | 2025-02-18T17:12:54Z      |                   |               |
+| [Update variables](https://github.com/casper-network/casper-sidecar/pull/406)                                                                                                    | 2025-02-18T17:08:49Z      |                   |               |
+| [CI Repo Publish Initial Test](https://github.com/casper-network/casper-sidecar/pull/405)                                                                                        | 2025-02-18T15:59:06Z      |                   |               |
+| [Increase the rate of heartbeat checks across default configs](https://github.com/casper-network/casper-sidecar/pull/403)                                                        | 2025-02-11T13:55:18Z      |                   |               |
+| [Rename SignedBlock to BlockWithSignatures](https://github.com/casper-network/casper-sidecar/pull/401)                                                                           | 2025-01-31T07:33:09Z      |                   |               |
+| [Cutting rc3](https://github.com/casper-network/casper-sidecar/pull/389)                                                                                                         | 2025-01-10T13:16:15Z      |                   |               |
+| [updating dependencies to reflect newest ""casper-types""](https://github.com/casper-network/casper-sidecar/pull/362)                                                            | 2024-11-19T15:20:51Z      |                   |               |
+| [Aligning code with recent changes to casper-types, fixing auction_inf…](https://github.com/casper-network/casper-sidecar/pull/366)                                              | 2024-11-25T15:57:17Z      |                   |               |
+| [aligning with node changes](https://github.com/casper-network/casper-sidecar/pull/382)                                                                                          | 2024-12-18T01:31:57Z      |                   |               |
+| [Repointing casper-node to v2.0.0-rc5](https://github.com/casper-network/casper-sidecar/pull/369)                                                                                | 2024-11-26T15:15:38Z      |                   |               |
+| [Aligning sidecar to latest changes in casper-node](https://github.com/casper-network/casper-sidecar/pull/367)                                                                   | 2024-11-26T12:20:56Z      |                   |               |
+| [Aligning code with recent changes in the node](https://github.com/casper-network/casper-sidecar/pull/374)                                                                       | 2024-12-04T12:19:58Z      |                   |               |
+| [Bumping dependencies](https://github.com/casper-network/casper-sidecar/pull/378)                                                                                                | 2024-12-10T22:20:09Z      |                   |               |
+| [Handle standard interrupt signals](https://github.com/casper-network/casper-sidecar/pull/375)                                                                                   | 2024-12-04T15:52:08Z      |                   |               |
+| [Use local duplicate of `AuctionState` struct](https://github.com/casper-network/casper-sidecar/pull/364)                                                                        | 2024-12-03T11:52:10Z      |                   |               |
+| [Validate network name if specified](https://github.com/casper-network/casper-sidecar/pull/357)                                                                                  | 2024-12-03T10:42:30Z      |                   |               |
+| [Implement keepalive checks](https://github.com/casper-network/casper-sidecar/pull/368)                                                                                          | 2024-11-26T13:20:26Z      |                   |               |
+| [Make IP & port config consistent across all node connections](https://github.com/casper-network/casper-sidecar/pull/358)                                                        | 2024-11-19T15:56:31Z      |                   |               |
+| [Add config typing for IP/socket addresses](https://github.com/casper-network/casper-sidecar/pull/353)                                                                           | 2024-11-13T14:17:35Z      |                   |               |
+| [RPC client graceful reconnect](https://github.com/casper-network/casper-sidecar/pull/349)                                                                                       | 2024-11-12T11:22:58Z      |                   |               |
+| [Feat track node 2.0](https://github.com/casper-ecosystem/casper-client-rs/pull/242)                                                                                             | 2025-03-13T15:55:26Z      |                   |               |
+| [Bumping rust version, putting Cargo.lock into the repo](https://github.com/casper-ecosystem/casper-client-rs/pull/240)                                                          | 2025-03-05T11:18:06Z      |                   |               |
+| [Change default pricing mode](https://github.com/casper-ecosystem/casper-client-rs/pull/236)                                                                                     | 2025-02-24T15:09:30Z      |                   |               |
+| [Updating publish to new infra.](https://github.com/casper-ecosystem/casper-client-rs/pull/234)                                                                                  | 2025-02-20T17:55:42Z      |                   |               |
+| [Rename transaction-path arg to wasm-path](https://github.com/casper-ecosystem/casper-client-rs/pull/231)                                                                        | 2025-02-13T09:04:40Z      |                   |               |
+| [Add `list-transactions` subcommand](https://github.com/casper-ecosystem/casper-client-rs/pull/228)                                                                              | 2025-01-24T16:05:07Z      |                   |               |
+| [Add `put-deploy` deprecation warning](https://github.com/casper-ecosystem/casper-client-rs/pull/224)                                                                            | 2025-01-24T16:02:39Z      |                   |               |
+| [Add contract package arg](https://github.com/casper-ecosystem/casper-client-rs/pull/226)                                                                                        | 2025-01-23T15:38:05Z      |                   |               |
+| [Pub DeployBuilder](https://github.com/casper-ecosystem/casper-client-rs/pull/220)                                                                                               | 2024-12-18T10:07:42Z      |                   |               |
+| [Applying arg_handling fixes to the client](https://github.com/casper-ecosystem/casper-client-rs/pull/216)                                                                       | 2024-12-10T21:53:35Z      |                   |               |
+| [Reflecting clients code to the fact that ""arg_handling"" module is now…](https://github.com/casper-ecosystem/casper-client-rs/pull/215)                                        | 2024-12-04T15:11:22Z      |                   |               |
+| [Aligning client code with recent node changes](https://github.com/casper-ecosystem/casper-client-rs/pull/218)                                                                   | 2024-12-11T09:21:41Z      |                   |               |
+| [Fix cancel reservations args](https://github.com/casper-ecosystem/casper-client-rs/pull/219)                                                                                    | 2024-12-12T08:39:04Z      |                   |               |
+| [Aligning client with recent changes of casper-types](https://github.com/casper-ecosystem/casper-client-rs/pull/204)                                                             | 2024-11-25T15:52:47Z      |                   |               |
+| [Making transferred-value optional in the CLI. Also, if VM1 is the sel…](https://github.com/casper-ecosystem/casper-client-rs/pull/208)                                          | 2024-11-27T17:28:34Z      |                   |               |
+| [Typo fixes](https://github.com/casper-ecosystem/casper-client-rs/pull/213)                                                                                                      | 2024-12-03T11:23:16Z      |                   |               |
+| [Add support for new auction entrypoints](https://github.com/casper-ecosystem/casper-client-rs/pull/207)                                                                         | 2024-11-29T14:30:10Z      |                   |               |
+| [Remove external transaction & deploy builder dependency](https://github.com/casper-ecosystem/casper-client-rs/pull/212)                                                         | 2024-11-29T12:20:57Z      |                   |               |
+| [Address refactor of Package to SmartContract](https://github.com/casper-ecosystem/casper-client-rs/pull/205)                                                                    | 2024-11-25T20:23:03Z      |                   |               |
+| [Remove --gas-limit parameter](https://github.com/casper-ecosystem/casper-client-rs/pull/200)                                                                                    | 2024-11-19T17:15:44Z      |                   |               |
+| [New execution engine support](https://github.com/casper-ecosystem/casper-client-rs/pull/199)                                                                                    | 2024-11-19T16:10:01Z      |                   |               |
+| [Update types latest changes](https://github.com/casper-ecosystem/casper-client-rs/pull/197)                                                                                     | 2024-11-07T02:56:43Z      |                   |               |
+| [arg install-upgrade bug](https://github.com/casper-ecosystem/casper-client-rs/pull/196)                                                                                         | 2024-10-31T12:07:34Z      |                   |               |
+| [Interaction with Casper smart-contract source code verification service for feat-2.0 branch](https://github.com/casper-ecosystem/casper-client-rs/pull/184)                     | 2024-10-28T10:04:47Z      |                   |               |
+| [Fix for remove of `as_entity_addr`](https://github.com/casper-ecosystem/casper-client-rs/pull/195)                                                                              | 2024-10-24T18:27:10Z      |                   |               |
+| [Complete feature std-fs-io in casper-client feat-2.0](https://github.com/casper-ecosystem/casper-client-rs/pull/153)                                                            | 2024-10-21T09:45:47Z      |                   |               |
+| [Changing TransactionV1 structure follwing https://github.com/casper-network/casper-node/pull/4890](https://github.com/casper-ecosystem/casper-client-rs/pull/191)               | 2024-10-17T14:21:47Z      |                   |               |
+| [Add json-schema to casper types import](https://github.com/casper-ecosystem/casper-client-rs/pull/193)                                                                          | 2024-10-15T17:53:40Z      |                   |               |
+| [Update `casper-contract` crate  + Message topic fix](https://github.com/casper-ecosystem/cep-78-enhanced-nft/pull/295)                                                          | 2025-03-25T16:17:04Z      |                   |               |
+| [EntityEntryPoint update](https://github.com/casper-ecosystem/cep-78-enhanced-nft/pull/294)                                                                                      | 2025-03-05T20:56:45Z      |                   |               |
+| [Update Feat 2.0 branch](https://github.com/casper-ecosystem/cep-78-enhanced-nft/pull/291)                                                                                       | 2025-02-12T12:44:22Z      |                   |               |
+| [Do not revert on upgrade with same events](https://github.com/casper-ecosystem/cep18/pull/160)                                                                                  | 2025-03-11T11:10:05Z      |                   |               |
+| [Update Feat 2.0 branch](https://github.com/casper-ecosystem/cep18/pull/158)                                                                                                     | 2025-01-28T18:41:18Z      |                   |               |
+| [Enable wasm32 compilation and runtime of the binary-port-access lib](https://github.com/casper-ecosystem/casper-binary-port-client/pull/1)                                      | 2025-02-04T09:02:38Z      |                   |               |
+| [Apply changes from https://github.com/casper-network/casper-node/pull/5089](https://github.com/casper-ecosystem/casper-binary-port-client/pull/10)                              | 2025-03-25T15:11:35Z      |                   |               |
+| [Make it possible to initialize COUNTER with a custom value](https://github.com/casper-ecosystem/casper-binary-port-client/pull/11)                                              | 2025-02-05T17:29:52Z      |                   |               |
+| [Rename SignedBlock to BlockWithSignatures](https://github.com/casper-ecosystem/casper-binary-port-client/pull/9)                                                                | 2025-02-04T15:11:44Z      |                   |               |
+| [Implementation of ""raw"" command](https://github.com/casper-ecosystem/casper-binary-port-client/pull/7)                                                                        | 2025-01-25T20:42:04Z      |                   |               |
+| [Update DelegatorKind](https://github.com/casper-ecosystem/casper-binary-port-client/pull/3)                                                                                     | 2025-01-17T11:01:36Z      |                   |               |


### PR DESCRIPTION
Removed numeric IDs, converted titles to links, renamed columns, and reordered fields to improve clarity and accessibility of the PR table.

The number column was unnecessary/not-useful because there were PRs from multiple repositories, possibly with colliding PR numbers.

This is how the table structure looks like now:
![new-format](https://github.com/user-attachments/assets/a4e51148-a231-47e8-a2c5-f1bffde47ff2)
