### PR TITLE
Drop Tor.us from the accounts and keys page

### DIFF
--- a/docs/concepts/accounts-and-keys.md
+++ b/docs/concepts/accounts-and-keys.md
@@ -101,7 +101,7 @@ This option is available on networks that have a block explorer.
 
 For instance, on the official Testnet, the [CSPR.live](https://testnet.cspr.live/) block explorer is available, and the following instructions assume you are using it.
 
-Start by creating an account using the [Casper Wallet](https://www.casperwallet.io/), [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?support=true), or [Torus Wallet](https://casper.tor.us/).
+Start by creating an account using the [Casper Wallet](https://www.casperwallet.io/) or [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?support=true).
 
 :::caution
 

--- a/versioned_docs/version-1.5.X/concepts/accounts-and-keys.md
+++ b/versioned_docs/version-1.5.X/concepts/accounts-and-keys.md
@@ -106,7 +106,7 @@ This option is available on networks that have a block explorer.
 
 For instance, on the official Testnet, the [CSPR.live](https://testnet.cspr.live/) block explorer is available, and the following instructions assume you are using it.
 
-Start by creating an account using the [Casper Wallet](https://www.casperwallet.io/), [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?support=true), or [Torus Wallet](https://casper.tor.us/).
+Start by creating an account using the [Casper Wallet](https://www.casperwallet.io/) or [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?support=true).
 
 :::caution
 

--- a/versioned_docs/version-2.0.0/concepts/accounts-and-keys.md
+++ b/versioned_docs/version-2.0.0/concepts/accounts-and-keys.md
@@ -101,7 +101,7 @@ This option is available on networks that have a block explorer.
 
 For instance, on the official Testnet, the [CSPR.live](https://testnet.cspr.live/) block explorer is available, and the following instructions assume you are using it.
 
-Start by creating an account using the [Casper Wallet](https://www.casperwallet.io/), [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?support=true), or [Torus Wallet](https://casper.tor.us/).
+Start by creating an account using the [Casper Wallet](https://www.casperwallet.io/) or [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?support=true).
 
 :::caution
 


### PR DESCRIPTION
Tor.us was removed from the ecosystem after September 30th, 2024