### PR TITLE
Remove Tor.us from the wallets list

### DIFF
--- a/docs/resources/build-on-casper.md
+++ b/docs/resources/build-on-casper.md
@@ -20,7 +20,6 @@ The Casper Ecosystem is growing every day through the addition of new dApps and 
 
 ### Wallets
 - [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?docs=true)
-- [Tor.us](https://casper.tor.us)
 - [Casper Wallet](https://www.casperwallet.io)
 - [Metamask](https://metamask.io/) with [Casper Snap](https://github.com/casper-ecosystem/casper-manager)
 

--- a/versioned_docs/version-1.5.X/resources/build-on-casper.md
+++ b/versioned_docs/version-1.5.X/resources/build-on-casper.md
@@ -22,7 +22,6 @@ The Casper Ecosystem is growing every day through the addition of new dApps and 
 
 ### Wallets
 - [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?docs=true)
-- [Tor.us](https://casper.tor.us)
 - [Casper Wallet](https://www.casperwallet.io)
 - [Metamask](https://metamask.io/) with [Casper Snap](https://github.com/casper-ecosystem/casper-manager)
 

--- a/versioned_docs/version-2.0.0/resources/build-on-casper.md
+++ b/versioned_docs/version-2.0.0/resources/build-on-casper.md
@@ -20,7 +20,6 @@ The Casper Ecosystem is growing every day through the addition of new dApps and 
 
 ### Wallets
 - [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?docs=true)
-- [Tor.us](https://casper.tor.us)
 - [Casper Wallet](https://www.casperwallet.io)
 - [Metamask](https://metamask.io/) with [Casper Snap](https://github.com/casper-ecosystem/casper-manager)
 


### PR DESCRIPTION
Tor.us was removed from the ecosystem after September 30th, 2024