### PR TITLE
Deleting Python SDK from Docs (CD-64)

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -182,8 +182,7 @@ module.exports = {
                         "developers/dapps/sdk/client-library-usage",
                         "developers/dapps/sdk/script-sdk",
                         "developers/dapps/sdk/csharp-sdk",
-                        "developers/dapps/sdk/go-sdk",
-                        "developers/dapps/sdk/python-sdk",
+                        "developers/dapps/sdk/go-sdk"
                     ],
                 },
                 "developers/dapps/technology-stack",

--- a/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/versioned_sidebars/version-2.0.0-sidebars.json
@@ -191,8 +191,7 @@
             "developers/dapps/sdk/client-library-usage",
             "developers/dapps/sdk/script-sdk",
             "developers/dapps/sdk/csharp-sdk",
-            "developers/dapps/sdk/go-sdk",
-            "developers/dapps/sdk/python-sdk"
+            "developers/dapps/sdk/go-sdk"
           ]
         },
         "developers/dapps/technology-stack",


### PR DESCRIPTION
Python SDK was decided to be removed from the docs since it's not supported at the moment.

The Sidebar was changed to not include the Python SDK.