### PR TITLE
Update Discord url and remove & replace other outdated links

### DIFF
--- a/config/theme.footer.config.js
+++ b/config/theme.footer.config.js
@@ -13,7 +13,7 @@ module.exports = {
     copyright: `Copyright © ${new Date().getFullYear()} Casper Association. Built with Docusaurus.`,
     links: [
         {
-            href: "https://discord.com/invite/casperblockchain",
+            href: "https://discord.gg/caspernetwork",
             label: "Discord",
             position: "right",
         },

--- a/config/theme.navbar.config.js
+++ b/config/theme.navbar.config.js
@@ -89,8 +89,8 @@ module.exports = {
             dropdownActiveClassDisabled: true,
         },
         // {
-        //     href: "https://support.casperlabs.io/",
-        //     label: "Support",
+        //     href: "https://forum.casper.network/",
+        //     label: "Forum",
         //     position: "right",
         // },
         // {

--- a/config/theme.navbar.config.js
+++ b/config/theme.navbar.config.js
@@ -94,7 +94,7 @@ module.exports = {
         //     position: "right",
         // },
         // {
-        //     href: "https://discord.com/invite/casperblockchain",
+        //     href: "https://discord.gg/caspernetwork",
         //     label: "Discord",
         //     position: "right",
         // },

--- a/docs/developers/prerequisites.md
+++ b/docs/developers/prerequisites.md
@@ -8,7 +8,7 @@ This page covers the necessary software for your Casper development environment.
 
 :::caution
 
-Casper does not officially support `macOS`. If you encounter any problems, reach out to the community on [Telegram](https://t.me/casperblockchain) or [Discord](https://discord.com/invite/casperblockchain).
+Casper does not officially support `macOS`. If you encounter any problems, reach out to the community on [Telegram](https://t.me/casperblockchain) or [Discord](https://discord.gg/caspernetwork).
 
 :::
 

--- a/docs/operators/becoming-a-validator/recovering.md
+++ b/docs/operators/becoming-a-validator/recovering.md
@@ -60,7 +60,7 @@ To check if your node is in sync, compare the current block height at [https://c
 curl -s localhost:8888/status | jq .last_added_block_info
 ```
 
-If you cannot figure out the issue, ask for help in the *node-tech-support* channel on [Discord](https://discord.com/invite/casperblockchain).
+If you cannot figure out the issue, ask for help in the *node-tech-support* channel on [Discord](https://discord.gg/caspernetwork).
 
 ## Activating the Bid
 

--- a/docs/resources/tokens/cep18/full-tutorial.md
+++ b/docs/resources/tokens/cep18/full-tutorial.md
@@ -102,7 +102,7 @@ This section briefly explains the contract methods used in the Casper Fungible T
 
 To see the full implementation of the below contract methods, refer to the [contract file](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs) in Github. If you have any questions, review the [casper_erc20](https://docs.rs/casper-erc20-crate/latest/casper_erc20_crate/) library and the [EIP-20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md#) standard.
 
-Also, for further unresolved issues please contact the Casper support team via the [Discord channel](https://discord.com/invite/casperblockchain).
+Also, for further unresolved issues please contact the Casper support team via the [Discord channel](https://discord.gg/caspernetwork).
 
 Contract methods are:
 

--- a/docs/users/delegating.md
+++ b/docs/users/delegating.md
@@ -28,7 +28,7 @@ undelegate = 2_500_000_000
 
 Delegation fees may change over time, so it is essential to stay current. To do so, select the latest release in [Github](https://github.com/casper-network/casper-node) and navigate to the `resources/production/chainspec.toml` file.
 
-For further questions, please join the [Discord channel](https://discord.com/invite/casperblockchain).
+For further questions, please join the [Discord channel](https://discord.gg/caspernetwork).
 
 ## Delegation Limits
 

--- a/docs/users/ledger/ledger-setup.md
+++ b/docs/users/ledger/ledger-setup.md
@@ -15,7 +15,7 @@ A Ledger device is a hardware wallet considered one of the most secure ways to s
 
 :::note
 
-If you need help, contact us on [Twitter](https://twitter.com/Casper_Network), [Discord](https://discord.com/invite/casperblockchain), or [Telegram](https://t.me/casperblockchain).
+If you need help, contact us on [Twitter](https://twitter.com/Casper_Network), [Discord](https://discord.gg/caspernetwork), or [Telegram](https://t.me/casperblockchain).
 
 :::
 

--- a/versioned_docs/version-1.5.X/concepts/economics/staking/delegation.md
+++ b/versioned_docs/version-1.5.X/concepts/economics/staking/delegation.md
@@ -22,7 +22,7 @@ For example, the chainspec file in release 1.3.2 will contain the following info
 
 Delegation fees may change over time, so, it is essential to stay up to date. To do so, select the latest release in [Github](https://github.com/casper-network/casper-node), and navigate to the chainspec.toml file.
 
-If you are unsure about anything, please join the [Discord channel](https://discord.com/invite/casperblockchain) to ask us questions.
+If you are unsure about anything, please join the [Discord channel](https://discord.gg/caspernetwork) to ask us questions.
 
 ## First-time Delegation
 

--- a/versioned_docs/version-1.5.X/concepts/glossary/A.md
+++ b/versioned_docs/version-1.5.X/concepts/glossary/A.md
@@ -12,7 +12,7 @@ An Account is a structure that represents a user on a Casper network. Informatio
 
 ## Account Hash {#account-hash}
 
-The account hash is a 32-byte hash of the public key representing the user account. Information on generating an account hash can be found [here](https://support.casperlabs.io/hc/en-gb/articles/13781616975131-How-do-I-generate-an-account-hash-).
+The account hash is a 32-byte hash of the public key representing the user account.
 
 ## AssemblyScript {#assemblyscript}
 

--- a/versioned_docs/version-1.5.X/developers/prerequisites.md
+++ b/versioned_docs/version-1.5.X/developers/prerequisites.md
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # Development Prerequisites
 
-This page covers the necessary software for your Casper development environment. To develop comfortably, you should use `Linux Ubuntu 20.04`. Casper does not officially support `macOS`, but the commands are included for your convenience. If you encounter any problems, reach out to the community on [Telegram](https://t.me/casperblockchain) or [Discord](https://discord.com/invite/casperblockchain). Developing on Windows is not advised.
+This page covers the necessary software for your Casper development environment. To develop comfortably, you should use `Linux Ubuntu 20.04`. Casper does not officially support `macOS`, but the commands are included for your convenience. If you encounter any problems, reach out to the community on [Telegram](https://t.me/casperblockchain) or [Discord](https://discord.gg/caspernetwork). Developing on Windows is not advised.
 
 ## Preparing your Development Environment
 

--- a/versioned_docs/version-1.5.X/developers/prerequisites.md
+++ b/versioned_docs/version-1.5.X/developers/prerequisites.md
@@ -264,9 +264,9 @@ The node address is the IP address or URL of a peer node.
 
 Casper Labs provides public Casper node JSON-RPC endpoints for each network:
 
-* Mainnet: https://rpc.mainnet.casperlabs.io/rpc
-* Testnet: https://node.testnet.casper.networkrpc
-* Integration network: https://rpc.integration.casperlabs.io/rpc
+* Mainnet: https://node.mainnet.casper.network/rpc
+* Testnet: https://node.testnet.casper.network/rpc
+* Integration network: https://node.integration.casper.network/rpc
 
 Additionally, both the official Testnet and Mainnet provide block explorers that list the IP addresses of nodes on their respective networks.
 

--- a/versioned_docs/version-1.5.X/operators/becoming-a-validator/recovering.md
+++ b/versioned_docs/version-1.5.X/operators/becoming-a-validator/recovering.md
@@ -60,7 +60,7 @@ To check if your node is in sync, compare the current block height at [https://c
 curl -s localhost:8888/status | jq .last_added_block_info
 ```
 
-If you cannot figure out the issue, ask for help in the *node-tech-support* channel on [Discord](https://discord.com/invite/casperblockchain).
+If you cannot figure out the issue, ask for help in the *node-tech-support* channel on [Discord](https://discord.gg/caspernetwork).
 
 ## Activating the Bid
 

--- a/versioned_docs/version-1.5.X/operators/maintenance/archiving-and-restoring.md
+++ b/versioned_docs/version-1.5.X/operators/maintenance/archiving-and-restoring.md
@@ -10,7 +10,7 @@ This documentation describes processes for the compression and decompression of 
 
 :::note
 
-The values presented in this document assume that the `trie-compact` tool was run on a Mainnet database for compression. Contact the [support team](https://support.casperlabs.io/hc/en-gb) if you have questions.
+The values presented in this document assume that the `trie-compact` tool was run on a Mainnet database for compression. Contact the support team on the [Casper Community and Governance Forum](https://forum.casper.network/c/ecosystem-support) if you have questions.
 
 :::
 

--- a/versioned_docs/version-1.5.X/operators/setup/install-node.md
+++ b/versioned_docs/version-1.5.X/operators/setup/install-node.md
@@ -127,9 +127,9 @@ NODE_ADDR can be set to an IP of a trusted node, or to Casper Labs' public nodes
 
 You can find active peers at https://cspr.live/tools/peers or use the following Casper Labs public nodes:
 
-* Testnet - NODE_ADDR=https://node.testnet.casper.network
+* Testnet - NODE_ADDR=https://node.testnet.casper.network/rpc
 
-* Mainnet - NODE_ADDR=https://rpc.mainnet.casperlabs.io
+* Mainnet - NODE_ADDR=https://node.mainnet.casper.network/rpc
 
 ### Protocol Version
 
@@ -144,7 +144,7 @@ PROTOCOL=1_5_2
 The following command uses the previously established NODE_ADDR and PROTOCOL to load the `trusted_hash`:
 
 ```bash
-NODE_ADDR=https://rpc.mainnet.casperlabs.io
+NODE_ADDR=https://node.mainnet.casper.network/rpc
 PROTOCOL=1_5_2
 sudo sed -i "/trusted_hash =/c\trusted_hash = '$(casper-client get-block --node-address $NODE_ADDR | jq -r .result.block.hash | tr -d '\n')'" /etc/casper/$PROTOCOL/config.toml
 ```

--- a/versioned_docs/version-1.5.X/operators/setup/node-endpoints.md
+++ b/versioned_docs/version-1.5.X/operators/setup/node-endpoints.md
@@ -206,7 +206,7 @@ sudo ufw enable
 
 These commands will limit requests to the available ports of your node. Port 35000 should be left open, although you can limit traffic, as it is crucial for node-to-node communication.
 
-If you have any concerns, questions, or issues, please [submit a request](https://support.casperlabs.io/hc/en-gb/requests/new) to the Casper support team.
+If you have any concerns, questions, or issues, please [submit a request](https://forum.casper.network/c/ecosystem-support) to the Casper support team.
 
 
 ## Restricting Access for Private Networks
@@ -229,5 +229,5 @@ Here is a summary of the links mentioned on this page:
 - [Confirming that the node is synchronized](./joining.md#step-7-confirm-the-node-is-synchronized)
 - [Monitoring and consuming events](../../developers/dapps/monitor-and-consume-events.md)
 - [Private network access control](../setup-network/create-private.md#network-access-control)
-- [FAQs for a basic validator node ](https://support.casperlabs.io/hc/en-gb/sections/6960448246683-Node-Operation-FAQ)
+- [Node Operator & Validator FAQ](https://docs.casper.network/faq/faq#-node-operator--validator-faq)
 - [External FAQs on Mainnet and Testnet validator node setup](https://docs.cspr.community/docs/faq-validator.html)

--- a/versioned_docs/version-1.5.X/resources/advanced/storage-workflow.md
+++ b/versioned_docs/version-1.5.X/resources/advanced/storage-workflow.md
@@ -18,7 +18,7 @@ Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/cont
 
 ### `storage::write` / `storage::read`
 
-[`storage::write`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.write.html) writes a given value to a previously established URef (created using [`storage::new_uref`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.new_uref.html)). Unlike `put_key`, this value is not one of the `Key` types listed above, but rather any of the potential [`CLType`](https://docs.casperlabs.io/developers/json-rpc/types_cl/#cltype)s as outlined. [`storage::read`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.read.html) provides a method to retrieve these values from the associated URef.
+[`storage::write`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.write.html) writes a given value to a previously established URef (created using [`storage::new_uref`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.new_uref.html)). Unlike `put_key`, this value is not one of the `Key` types listed above, but rather any of the potential [`CLType`](https://docs.casper.network/developers/json-rpc/types_cl/#cltype)s as outlined. [`storage::read`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.read.html) provides a method to retrieve these values from the associated URef.
 
 ### `storage:dictionary_put` / `storage::dictionary_get`
 

--- a/versioned_docs/version-1.5.X/resources/tokens/cep18/full-tutorial.md
+++ b/versioned_docs/version-1.5.X/resources/tokens/cep18/full-tutorial.md
@@ -102,7 +102,7 @@ This section briefly explains the contract methods used in the Casper Fungible T
 
 To see the full implementation of the below contract methods, refer to the [contract file](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs) in Github. If you have any questions, review the [casper_erc20](https://docs.rs/casper-erc20-crate/latest/casper_erc20_crate/) library and the [EIP-20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md#) standard.
 
-Also, for further unresolved issues please contact the Casper support team via the [Discord channel](https://discord.com/invite/casperblockchain).
+Also, for further unresolved issues please contact the Casper support team via the [Discord channel](https://discord.gg/caspernetwork).
 
 Contract methods are:
 

--- a/versioned_docs/version-1.5.X/resources/tokens/cep78/using-casper-client/full-installation-tutorial.md
+++ b/versioned_docs/version-1.5.X/resources/tokens/cep78/using-casper-client/full-installation-tutorial.md
@@ -100,7 +100,7 @@ Initializing the contract happens through the `call() -> install_contract() -> i
 
 ### Contract Entrypoints
 
-This section briefly explains the essential entrypoints used in the Casper NFT contract. To see their full implementation, refer to the [main.rs](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/dev/contract/src/main.rs) contract file. For further questions, contact the Casper support team via the [Discord channel](https://discord.com/invite/casperblockchain).
+This section briefly explains the essential entrypoints used in the Casper NFT contract. To see their full implementation, refer to the [main.rs](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/dev/contract/src/main.rs) contract file. For further questions, contact the Casper support team via the [Discord channel](https://discord.gg/caspernetwork).
 
 - [**approve**](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/440bff44277ab5fd295f37229fe92278339d3753/contract/src/main.rs#L1002) - Allows a spender to transfer up to an amount of the owners’s tokens
 - [**balance_of**](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/440bff44277ab5fd295f37229fe92278339d3753/contract/src/main.rs#L1616) - Returns the token balance of the owner

--- a/versioned_docs/version-1.5.X/users/ledger/ledger-setup.md
+++ b/versioned_docs/version-1.5.X/users/ledger/ledger-setup.md
@@ -17,7 +17,7 @@ A Ledger device is a hardware wallet considered one of the most secure ways to s
 
 :::note
 
-If you need help, contact us on [Twitter](https://twitter.com/Casper_Network), [Discord](https://discord.com/invite/casperblockchain), or [Telegram](https://t.me/casperblockchain).
+If you need help, contact us on [Twitter](https://twitter.com/Casper_Network), [Discord](https://discord.gg/caspernetwork), or [Telegram](https://t.me/casperblockchain).
 
 :::
 

--- a/versioned_docs/version-2.0.0/developers/prerequisites.md
+++ b/versioned_docs/version-2.0.0/developers/prerequisites.md
@@ -8,7 +8,7 @@ This page covers the necessary software for your Casper development environment.
 
 :::caution
 
-Casper does not officially support `macOS`. If you encounter any problems, reach out to the community on [Telegram](https://t.me/casperblockchain) or [Discord](https://discord.com/invite/casperblockchain).
+Casper does not officially support `macOS`. If you encounter any problems, reach out to the community on [Telegram](https://t.me/casperblockchain) or [Discord](https://discord.gg/caspernetwork).
 
 :::
 

--- a/versioned_docs/version-2.0.0/operators/becoming-a-validator/recovering.md
+++ b/versioned_docs/version-2.0.0/operators/becoming-a-validator/recovering.md
@@ -60,7 +60,7 @@ To check if your node is in sync, compare the current block height at [https://c
 curl -s localhost:8888/status | jq .last_added_block_info
 ```
 
-If you cannot figure out the issue, ask for help in the *node-tech-support* channel on [Discord](https://discord.com/invite/casperblockchain).
+If you cannot figure out the issue, ask for help in the *node-tech-support* channel on [Discord](https://discord.gg/caspernetwork).
 
 ## Activating the Bid
 

--- a/versioned_docs/version-2.0.0/resources/tokens/cep18/full-tutorial.md
+++ b/versioned_docs/version-2.0.0/resources/tokens/cep18/full-tutorial.md
@@ -102,7 +102,7 @@ This section briefly explains the contract methods used in the Casper Fungible T
 
 To see the full implementation of the below contract methods, refer to the [contract file](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs) in Github. If you have any questions, review the [casper_erc20](https://docs.rs/casper-erc20-crate/latest/casper_erc20_crate/) library and the [EIP-20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md#) standard.
 
-Also, for further unresolved issues please contact the Casper support team via the [Discord channel](https://discord.com/invite/casperblockchain).
+Also, for further unresolved issues please contact the Casper support team via the [Discord channel](https://discord.gg/caspernetwork).
 
 Contract methods are:
 

--- a/versioned_docs/version-2.0.0/users/delegating.md
+++ b/versioned_docs/version-2.0.0/users/delegating.md
@@ -28,7 +28,7 @@ undelegate = 2_500_000_000
 
 Delegation fees may change over time, so it is essential to stay current. To do so, select the latest release in [Github](https://github.com/casper-network/casper-node) and navigate to the `resources/production/chainspec.toml` file.
 
-For further questions, please join the [Discord channel](https://discord.com/invite/casperblockchain).
+For further questions, please join the [Discord channel](https://discord.gg/caspernetwork).
 
 ## Delegation Limits
 

--- a/versioned_docs/version-2.0.0/users/ledger/ledger-setup.md
+++ b/versioned_docs/version-2.0.0/users/ledger/ledger-setup.md
@@ -15,7 +15,7 @@ A Ledger device is a hardware wallet considered one of the most secure ways to s
 
 :::note
 
-If you need help, contact us on [Twitter](https://twitter.com/Casper_Network), [Discord](https://discord.com/invite/casperblockchain), or [Telegram](https://t.me/casperblockchain).
+If you need help, contact us on [Twitter](https://twitter.com/Casper_Network), [Discord](https://discord.gg/caspernetwork), or [Telegram](https://t.me/casperblockchain).
 
 :::
 


### PR DESCRIPTION
- The new official url for Discord is https://discord.gg/caspernetwork
- Remove/replace casperlabs links