### PR TITLE
Fix operator folder struct in sidebar.js

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -250,8 +250,7 @@ module.exports = {
                 "operators/setup/node-endpoints",
                 "operators/setup/install-node",
                 "operators/setup/fast-sync",
-                "operators/setup/open-files",
-                "operators/setup/upgrade",
+                "operators/setup/open-files",                
                 "operators/setup/joining",
                 "operators/setup/non-root-user",
                 "operators/setup/node-events",
@@ -283,7 +282,11 @@ module.exports = {
                 type: "doc",
                 id: "operators/maintenance/index",
             },
-            items: ["operators/maintenance/archiving-and-restoring", "operators/maintenance/moving-node"],
+            items: [
+                "operators/maintenance/archiving-and-restoring", 
+                "operators/maintenance/moving-node",
+                "operators/maintenance/upgrade",
+            ],
         },
     ],
     resources: [

--- a/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/versioned_sidebars/version-2.0.0-sidebars.json
@@ -258,8 +258,7 @@
         "operators/setup/node-endpoints",
         "operators/setup/install-node",
         "operators/setup/fast-sync",
-        "operators/setup/open-files",
-        "operators/setup/upgrade",
+        "operators/setup/open-files",        
         "operators/setup/joining",
         "operators/setup/non-root-user",
         "operators/setup/node-events",
@@ -293,7 +292,8 @@
       },
       "items": [
         "operators/maintenance/archiving-and-restoring",
-        "operators/maintenance/moving-node"
+        "operators/maintenance/moving-node",
+        "operators/maintenance/upgrade"
       ]
     }
   ],


### PR DESCRIPTION
PR to fix the error encountered in the previous docs-redux [build](https://github.com/casper-network/docs-infra/actions/runs/15206191664/job/42769770054).

```bash
#14 4.655 [ERROR] Error: Unable to build website for locale en.
#14 4.655     at tryToBuildLocale (/app/node_modules/@docusaurus/core/lib/commands/build/build.js:78:15)
#14 4.655     at async /app/node_modules/@docusaurus/core/lib/commands/build/build.js:34:9
#14 4.655     ... 4 lines matching cause stack trace ...
#14 4.655     at async file:///app/node_modules/@docusaurus/core/bin/docusaurus.mjs:44:3 {
#14 4.655   [cause]: Error: Invalid sidebar file at "config/sidebar.config.js".
#14 4.655   These sidebar document ids do not exist:
#14 4.655   - operators/setup/upgrade 
```

The necessary changes were carried out in the following files;

```
config/sidebar.config.js
versioned_sidebars/version-2.0.0-sidebars.json
```