### PR TITLE
Add new Security Audit Reports page [CD-102]

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -414,6 +414,18 @@ module.exports = {
                 //"resources/advanced/list-cspr",
             ],
         },
+        {
+            type: "category",
+            label: "Security Audit Reports",
+            collapsible: true,
+            collapsed: true,
+            link: {
+                type: "doc",
+                id: "resources/audit-reports/index",
+            },
+            items: [                
+            ],
+        },
     ],
     users: [
         "users/index",

--- a/docs/resources/audit-reports/index.md
+++ b/docs/resources/audit-reports/index.md
@@ -23,10 +23,15 @@ The standardized audit reports provide comprehensive insights into security asse
 
 ## Audit Information
 
-| Project | Prepared by | Last Updated |  Remediation Status | Full Report |
+| Project | Prepared by | Report Date/Last Updated |  Remediation Status | Full Report |
 |---------|-------------|--------------|---------------------|-------------|
+| Bridge Contracts | HALBORN | 07/17/2024 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/casper---allbridge-fa8c33) |
+| Shiboo Token - Simplified | HALBORN | 08/21/2024 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/casper---shiboo-token---simplified-assessment-70b767) |
 | Casper 2.0 - Casper Association | HALBORN | 04/17/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/casper-20-12a8fb) |
-| Liquid Staking | HALBORN |  05/27/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/odra---liquid-staking-231379) |
+| Odra - Liquid Staking | HALBORN |  05/27/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/odra---liquid-staking-231379) |
+| MAKE CSPR.name | HALBORN |  07/03/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/make-csprname-7b1108) |
+| CEP18 | HALBORN |  07/21/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/cep18-799d0b) |
+
 
 
 ## Important Notice 

--- a/docs/resources/audit-reports/index.md
+++ b/docs/resources/audit-reports/index.md
@@ -1,0 +1,48 @@
+# Casper Network Security Audit Reports
+
+Welcome to Casper Network's official security audit documentation. 
+
+Our security audit program encompasses both core network infrastructure and ecosystem projects, ensuring comprehensive coverage across the entire Casper Network landscape.
+
+## Purpose
+This page serves as your central hub for accessing security audit reports across the Casper Network ecosystem, by consolidating and sharing security audit reports to promote transparency and enable the ecosystem to make informed decisions about project security.
+
+## Report Format
+
+The standardized audit reports provide comprehensive insights into security assessments:
+
+**Executive Summary** A high-level overview of key findings, risk assessments, and overall security posture suitable for technical and non-technical stakeholders.
+
+**Audit Scope and Methodology** Detailed information about what was assessed, testing approaches used, and the audit framework applied to ensure thorough coverage.
+
+**Findings and Recommendations** Complete documentation of identified vulnerabilities, security improvements, and actionable recommendations categorized by severity level.
+
+**Remediation Status** Current status of addressed findings, implementation timelines, and verification of fixes where applicable.
+
+**Auditor Information** Details about the auditing firm, their credentials, expertise areas, and methodology standards to help you assess report credibility.
+
+## Audit Information
+
+| Project | Prepared by | Last Updated |  Remediation Status | Full Report |
+|---------|-------------|--------------|---------------------|-------------|
+| Casper 2.0 - Casper Association | HALBORN | 04/17/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/casper-20-12a8fb) |
+| Liquid Staking | HALBORN |  05/27/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/odra---liquid-staking-231379) |
+
+
+## Important Notice 
+
+Security audit reports represent findings at the specific time of assessment. The dynamic nature of software development means that:
+
+Projects may have implemented security fixes and updates since the original audit date
+New features or modifications may have been introduced that weren't part of the original scope
+We recommend verifying the current security status directly with project teams before making integration decisions
+
+For the most current security information, we encourage you to review the latest available reports and contact project maintainers for recent updates.
+
+## Continuous Security Improvement
+
+This documentation represents our ongoing commitment to security excellence. We regularly update our audit repository with new reports and maintain current remediation status information to ensure the community has access to the most accurate and up-to-date security intelligence.
+
+## Contact
+
+For questions about submissions or repository access, please open an issue or contact the Casper Network team through our official support channels for detailed discussions about findings or methodologies.

--- a/versioned_docs/version-2.0.0/resources/audit-reports/index.md
+++ b/versioned_docs/version-2.0.0/resources/audit-reports/index.md
@@ -23,11 +23,14 @@ The standardized audit reports provide comprehensive insights into security asse
 
 ## Audit Information
 
-| Project | Prepared by | Last Updated |  Remediation Status | Full Report |
+| Project | Prepared by | Report Date/Last Updated |  Remediation Status | Full Report |
 |---------|-------------|--------------|---------------------|-------------|
+| Bridge Contracts | HALBORN | 07/17/2024 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/casper---allbridge-fa8c33) |
+| Shiboo Token - Simplified | HALBORN | 08/21/2024 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/casper---shiboo-token---simplified-assessment-70b767) |
 | Casper 2.0 - Casper Association | HALBORN | 04/17/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/casper-20-12a8fb) |
-| Liquid Staking | HALBORN |  05/27/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/odra---liquid-staking-231379) |
-
+| Odra - Liquid Staking | HALBORN |  05/27/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/odra---liquid-staking-231379) |
+| MAKE CSPR.name | HALBORN |  07/03/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/make-csprname-7b1108) |
+| CEP18 | HALBORN |  07/21/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/cep18-799d0b) |
 
 ## Important Notice 
 

--- a/versioned_docs/version-2.0.0/resources/audit-reports/index.md
+++ b/versioned_docs/version-2.0.0/resources/audit-reports/index.md
@@ -1,0 +1,48 @@
+# Casper Network Security Audit Reports
+
+Welcome to Casper Network's official security audit documentation. 
+
+Our security audit program encompasses both core network infrastructure and ecosystem projects, ensuring comprehensive coverage across the entire Casper Network landscape.
+
+## Purpose
+This page serves as your central hub for accessing security audit reports across the Casper Network ecosystem, by consolidating and sharing security audit reports to promote transparency and enable the ecosystem to make informed decisions about project security.
+
+## Report Format
+
+The standardized audit reports provide comprehensive insights into security assessments:
+
+**Executive Summary** A high-level overview of key findings, risk assessments, and overall security posture suitable for technical and non-technical stakeholders.
+
+**Audit Scope and Methodology** Detailed information about what was assessed, testing approaches used, and the audit framework applied to ensure thorough coverage.
+
+**Findings and Recommendations** Complete documentation of identified vulnerabilities, security improvements, and actionable recommendations categorized by severity level.
+
+**Remediation Status** Current status of addressed findings, implementation timelines, and verification of fixes where applicable.
+
+**Auditor Information** Details about the auditing firm, their credentials, expertise areas, and methodology standards to help you assess report credibility.
+
+## Audit Information
+
+| Project | Prepared by | Last Updated |  Remediation Status | Full Report |
+|---------|-------------|--------------|---------------------|-------------|
+| Casper 2.0 - Casper Association | HALBORN | 04/17/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/casper-20-12a8fb) |
+| Liquid Staking | HALBORN |  05/27/2025 | 100% of all REPORTED Findings have been addressed | [Link](https://www.halborn.com/audits/casper-association/odra---liquid-staking-231379) |
+
+
+## Important Notice 
+
+Security audit reports represent findings at the specific time of assessment. The dynamic nature of software development means that:
+
+Projects may have implemented security fixes and updates since the original audit date
+New features or modifications may have been introduced that weren't part of the original scope
+We recommend verifying the current security status directly with project teams before making integration decisions
+
+For the most current security information, we encourage you to review the latest available reports and contact project maintainers for recent updates.
+
+## Continuous Security Improvement
+
+This documentation represents our ongoing commitment to security excellence. We regularly update our audit repository with new reports and maintain current remediation status information to ensure the community has access to the most accurate and up-to-date security intelligence.
+
+## Contact
+
+For questions about submissions or repository access, please open an issue or contact the Casper Network team through our official support channels for detailed discussions about findings or methodologies.

--- a/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/versioned_sidebars/version-2.0.0-sidebars.json
@@ -424,6 +424,18 @@
         "resources/advanced/storage-workflow",
         "resources/advanced/cross-contract"
       ]
+    },
+    {
+      "type": "category",
+      "label": "Security Audit Reports",
+      "collapsible": true,
+      "collapsed": true,
+      "link": {
+        "type": "doc",
+        "id": "resources/audit-reports/index"
+      },
+      "items": [        
+      ]
     }
   ],
   "users": [
@@ -542,6 +554,6 @@
         "resources/advanced/storage-workflow",
         "resources/advanced/cross-contract"
       ]
-    }
+    }    
   ]
 }


### PR DESCRIPTION
This PR resolves Jira ticket [CD-102](https://casper-association.atlassian.net/browse/CD-102).

Description:
- The aim of this change is to create a new subpage under the `Resources` section of the documentation to host Casper Security Audit reports.

- Please find the local test screenshot and attached PDF for how the new page will look like.
<img width="1857" height="994" alt="image" src="https://github.com/user-attachments/assets/a4362817-99dc-4e79-8ac2-b02ebdb44db7" />

[Casper Network Security Audit Reports _ Casper Docs.pdf](https://github.com/user-attachments/files/21382751/Casper.Network.Security.Audit.Reports._.Casper.Docs.pdf)

Changelog:
```sh
        modified:   config/sidebar.config.js
        new file:   docs/resources/audit-reports/index.md
        new file:   versioned_docs/version-2.0.0/resources/audit-reports/index.md
        modified:   versioned_sidebars/version-2.0.0-sidebars.json
```


[CD-102]: https://casper-association.atlassian.net/browse/CD-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ